### PR TITLE
Trying to get property of non-object in filter_image_downsize

### DIFF
--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -219,6 +219,13 @@ class Timmy {
 		$attachment = get_post( $attachment_id );
 
 		/**
+		 * Bail out if passed attachment id does not yield to a correct attachment.
+		 */
+		if ( $attachment === NULL ) {
+			return $return;
+		}
+
+		/**
 		 * Bail out if we try to downsize an SVG file or if we are in the backend
 		 * and want to load a GIF.
 		 *


### PR DESCRIPTION
After upgrading wordpress to 4.7 and Timber to 1.1.12 I've experienced
a 'Trying to get property of non-object' error message in the
filter_image_downsize function as an attachment for the passed
attachment id does not exist.

This patch checks if the attachment returned by get_post is no
non-object and bails out of this function accordingly.