### PR TITLE
added Composer's type package attribute set to 'wordpress-plugin'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "mindkomm/timmy",
+    "type": "wordpress-plugin",
     "description": "Advanced image manipulation for Timber.",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
in this way Timmy can be installed via Composer to a correct directory, instead of being installed to vendor/mindkomm/timmy folder