### PR TITLE
Add support for Responsive Content Images for Image Blocks in the Block Editor

### DIFF
--- a/lib/Responsive_Content_Images.php
+++ b/lib/Responsive_Content_Images.php
@@ -39,8 +39,19 @@ class Responsive_Content_Images {
 	 * Inits hooks.
 	 */
 	public function init() {
-		// Remove the default filter used by WordPress.
-		remove_filter( 'the_content', 'wp_make_content_images_responsive' );
+		/**
+		 * Remove the default filter used by WordPress.
+		 *
+		 * As of WordPress 5.5, the wp_make_content_images_responsive() function is deprecated and
+		 * replaced with wp_filter_content_tags().
+		 *
+		 * @see wp_filter_content_tags()
+		 */
+		if ( function_exists( 'wp_filter_content_tags' ) ) {
+			remove_filter( 'the_content', 'wp_filter_content_tags' );
+		} else {
+			remove_filter( 'the_content', 'wp_make_content_images_responsive' );
+		}
 
 		// Add our own custom filter.
 		add_filter( 'the_content', array( $this, 'make_content_images_responsive' ) );
@@ -52,7 +63,7 @@ class Responsive_Content_Images {
 	/**
 	 * Filter content and apply responsive image markup to images.
 	 *
-	 * @see wp_make_content_images_responsive()
+	 * @see wp_filter_content_tags()
 	 *
 	 * @param string $content Post content.
 	 *

--- a/lib/Responsive_Content_Images.php
+++ b/lib/Responsive_Content_Images.php
@@ -7,6 +7,13 @@ namespace Timmy;
  */
 class Responsive_Content_Images {
 	/**
+	 * Args.
+	 *
+	 * @var array
+	 */
+	protected $args;
+
+	/**
 	 * Responsive_Content_Images constructor.
 	 *
 	 * @param array $args {
@@ -25,6 +32,13 @@ class Responsive_Content_Images {
 			'map_sizes' => array(),
 		) );
 
+		$this->init();
+	}
+
+	/**
+	 * Inits hooks.
+	 */
+	public function init() {
 		// Remove the default filter used by WordPress.
 		remove_filter( 'the_content', 'wp_make_content_images_responsive' );
 
@@ -45,11 +59,41 @@ class Responsive_Content_Images {
 	 * @return string Filtered content
 	 */
 	public function make_content_images_responsive( $content ) {
-		// Select images in content
-		if ( ! preg_match_all( '/<img [^>]+>/', $content, $matches ) ) {
+		// Select images in content.
+		if ( ! preg_match_all( '/<img [^>]+>/', $content, $classic_images ) ) {
 			return $content;
 		}
 
+		/**
+		 * Check for Gutenberg blocks.
+		 *
+		 * This is possibly not the best way to do it, but it works.
+		 *
+		 * Matches all figures with class "wp-block-image" and "size-" classes. The part is after
+		 * "size-" is a capturing group to catch the image size that’s used.
+		 */
+		if ( preg_match_all(
+			'/<figure class="[^"]*wp-block-image size-([^\s]+)\s?[^"]*"[^>]*><img [^>]+><\/figure>/',
+			$content,
+			$block_images
+		) ) {
+			return $this->handle_block_images( $content, $block_images );
+		}
+
+		return $this->handle_classic_images( $content, $classic_images );
+	}
+
+	/**
+	 * Handles images define as blocks.
+	 *
+	 * @since 0.14.5
+	 *
+	 * @param string $content      Post content.
+	 * @param array  $block_images An array of regex matches.
+	 *
+	 * @return string
+	 */
+	public function handle_block_images( $content, $block_images ) {
 		$selected_images = array();
 		$attachment_ids  = array();
 
@@ -58,7 +102,20 @@ class Responsive_Content_Images {
 		 *
 		 * Ignore images that already contain a srcset.
 		 */
-		foreach ( $matches[0] as $image ) {
+		foreach ( $block_images[0] as $match_key => $figure ) {
+			// Get all images.
+			if ( ! preg_match( '/<img [^>]+>/', $figure, $image_match ) ) {
+				continue;
+			}
+
+			$image_size = $block_images[1][ $match_key ];
+			$image      = $image_match[0];
+
+			// Bailout if image size couldn’t be read.
+			if ( ! $image_size ) {
+				continue;
+			}
+
 			if ( false === strpos( $image, ' srcset=' )
 				&& preg_match( '/wp-image-([0-9]+)/i', $image, $class_id )
 				&& ( $attachment_id = absint( $class_id[1] ) )
@@ -67,13 +124,78 @@ class Responsive_Content_Images {
 				 * If exactly the same image tag is used more than once, overwrite it.
 				 * All identical tags will be replaced later with str_replace().
 				 */
-				$selected_images[ $image ] = $attachment_id;
+				$selected_images[ $image ] = [
+					'attachment_id' => $attachment_id,
+					'image_size'    => $image_size,
+				];
 
 				// Overwrite the ID when the same image is included more than once.
 				$attachment_ids[ $attachment_id ] = true;
 			}
 		}
 
+		return $this->handle_images( $content, $selected_images, $attachment_ids );
+	}
+
+	/**
+	 * Handles images added through the classic editor.
+	 *
+	 * @param string $content        Post content.
+	 * @param array  $classic_images An array of regex matches.
+	 *
+	 * @return string
+	 */
+	public function handle_classic_images( $content, $classic_images ) {
+		$selected_images = array();
+		$attachment_ids  = array();
+
+		/**
+		 * Loop through possible images and get attachment ids.
+		 *
+		 * Ignore images that already contain a srcset.
+		 */
+		foreach ( $classic_images[0] as $image ) {
+			if ( false === strpos( $image, ' srcset=' )
+				&& preg_match( '/wp-image-([0-9]+)/i', $image, $class_id )
+				&& ( $attachment_id = absint( $class_id[1] ) )
+			) {
+				// Select image size from classname starting with 'size-'.
+				$image_size = preg_match( '/ size-([^\s"]+)/', $image, $match_size )
+					? $match_size[1]
+					: false;
+
+				// Bailout if image size couldn’t be read.
+				if ( ! $image_size ) {
+					continue;
+				}
+
+				/**
+				 * If exactly the same image tag is used more than once, overwrite it.
+				 * All identical tags will be replaced later with str_replace().
+				 */
+				$selected_images[ $image ] = [
+					'attachment_id' => $attachment_id,
+					'image_size'    => $image_size,
+				];
+
+				// Overwrite the ID when the same image is included more than once.
+				$attachment_ids[ $attachment_id ] = true;
+			}
+		}
+
+		return $this->handle_images( $content, $selected_images, $attachment_ids );
+	}
+
+	/**
+	 * Handles replacing the image markup with Timmy markup.
+	 *
+	 * @param string $content         Post content.
+	 * @param array  $selected_images An array of image data.
+	 * @param array  $attachment_ids  An array of attachment IDs to warm object cache.
+	 *
+	 * @return string|string[]
+	 */
+	public function handle_images( $content, $selected_images, $attachment_ids ) {
 		/**
 		 * Warm object cache for use with 'get_post_meta()'.
 		 *
@@ -84,9 +206,9 @@ class Responsive_Content_Images {
 			update_meta_cache( 'post', array_keys( $attachment_ids ) );
 		}
 
-		// Loop through images and apply responsive markup
-		foreach ( $selected_images as $image => $attachment_id ) {
-			$image_updated = $this->generate_srcset_and_sizes( $image, $attachment_id );
+		// Loop through images and apply responsive markup.
+		foreach ( $selected_images as $image => $image_data ) {
+			$image_updated = $this->generate_srcset_and_sizes( $image, $image_data );
 			$content       = str_replace( $image, $image_updated, $content );
 		}
 
@@ -96,14 +218,16 @@ class Responsive_Content_Images {
 	/**
 	 * Updates image tag with responsive srcset and sizes attributes.
 	 *
-	 * @param string $image         HTML image tag.
-	 * @param int    $attachment_id Attachment ID.
+	 * @param string $image HTML image tag.
+	 * @param int    $data  Image data.
 	 *
 	 * @return string Reponsive image markup
 	 */
-	public function generate_srcset_and_sizes( $image, $attachment_id ) {
+	public function generate_srcset_and_sizes( $image, $data ) {
 		// Ensure the image meta exists.
-		$image_src = preg_match( '/src="([^"]+)"/', $image, $match_src ) ? $match_src[1] : '';
+		$image_src = preg_match( '/src="([^"]+)"/', $image, $match_src )
+			? $match_src[1]
+			: '';
 
 		list( $image_src ) = explode( '?', $image_src );
 
@@ -112,13 +236,8 @@ class Responsive_Content_Images {
 			return $image;
 		}
 
-		// Select image size from classname starting with 'size-'.
-		$img_size = preg_match( '/ size-([^\s"]+)/', $image, $match_size ) ? $match_size[1] : false;
-
-		// Bailout if image size couldn’t be read.
-		if ( ! $img_size ) {
-			return $image;
-		}
+		$img_size      = $data['image_size'];
+		$attachment_id = $data['attachment_id'];
 
 		// Maybe select replacement size.
 		if ( ! empty( $this->args['map_sizes'] ) ) {
@@ -142,7 +261,7 @@ class Responsive_Content_Images {
 			return $image;
 		}
 
-		// Remove existing src
+		// Remove existing src.
 		$image = preg_replace( '/ src="([^"]+)"/', '', $image );
 
 		/**
@@ -176,7 +295,7 @@ class Responsive_Content_Images {
 			$img_size
 		);
 
-		// Replace image markup
+		// Replace image markup.
 		$image = preg_replace(
 			'/<img ([^>]+?)[\/ ]*>/',
 			'<img $1 ' . Helper::get_attribute_html( $attributes ) . ' />',

--- a/tests/test-responsive-content-images.php
+++ b/tests/test-responsive-content-images.php
@@ -1,0 +1,78 @@
+<?php
+
+use Timmy\Responsive_Content_Images;
+
+/**
+ * Class TestResponsiveContentImages
+ */
+class TestResponsiveContentImages extends TimmyUnitTestCase {
+	public function test_classic_image() {
+		$image = $this->create_image();
+		$rci   = new Responsive_Content_Images();
+
+		$content = sprintf(
+			'<p><img class="alignnone size-responsive-content-image wp-image-%2$s" src="%1$s/test-400x0-c-default.jpg" alt="" width="400" /></p>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+
+		$expected = sprintf(
+			'<p><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" alt="" class="alignnone size-responsive-content-image wp-image-%2$s"></p>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+		$result = $rci->make_content_images_responsive( $content );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	public function test_block_image() {
+		$image = $this->create_image();
+		$rci   = new Responsive_Content_Images();
+
+		$content = trim( do_blocks( sprintf( '<!-- wp:image {"id":40,"sizeSlug":"responsive-content-image"} -->
+<figure class="wp-block-image size-responsive-content-image"><img src="%1$s/dog-400x0-c-default.jpg" alt="" class="wp-image-%2$s"/></figure>
+<!-- /wp:image -->',
+			$this->get_upload_url(),
+			$image->ID
+		) ) );
+
+		$expected = sprintf(
+			'<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" alt="" class="wp-image-%2$s"></figure>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+		$result = $rci->make_content_images_responsive( $content );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	public function test_combined_classic_and_block_images() {
+		$image = $this->create_image();
+		$rci   = new Responsive_Content_Images();
+
+		$content = sprintf(
+			'<p><img class="alignnone size-responsive-content-image wp-image-%2$s" src="%1$s/test-400x0-c-default.jpg" alt="" width="400" /></p>
+
+<!-- wp:image {"id":40,"sizeSlug":"responsive-content-image"} -->
+<figure class="wp-block-image size-responsive-content-image"><img src="%1$s/dog-400x0-c-default.jpg" alt="" class="wp-image-%2$s"/></figure>
+<!-- /wp:image -->',
+			$this->get_upload_url(),
+			$image->ID
+		);
+
+		$content = trim( do_blocks( $content ) );
+
+		$expected = sprintf(
+			'<p><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" alt="" class="alignnone size-responsive-content-image wp-image-%2$s"></p>
+
+
+<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" alt="" class="wp-image-%2$s"></figure>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+		$result = $rci->make_content_images_responsive( $content );
+
+		$this->assertEquals( $expected, $result );
+	}
+}

--- a/tests/test-responsive-content-images.php
+++ b/tests/test-responsive-content-images.php
@@ -75,4 +75,73 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	function test_block_image_with_figcaption() {
+		$image = $this->create_image();
+		$rci   = new Responsive_Content_Images();
+
+		$content = sprintf( '<!-- wp:image {"id":40,"sizeSlug":"responsive-content-image"} -->
+<figure class="wp-block-image size-responsive-content-image"><img src="%1$s/dog-400x0-c-default.jpg" alt="" class="wp-image-%2$s"/><figcaption>Image with a caption and a break<br>at 100%</figcaption></figure>
+<!-- /wp:image -->',
+			$this->get_upload_url(),
+			$image->ID
+		);
+
+		$content = trim( do_blocks( $content ) );
+
+		$expected = sprintf(
+			'<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" alt="" class="wp-image-%2$s"><figcaption>Image with a caption and a break<br>at 100/figcaption></figure>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+		$result = $rci->make_content_images_responsive( $content );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	function test_block_image_resized_at_75_percent() {
+		$image = $this->create_image();
+		$rci   = new Responsive_Content_Images();
+
+		$content = sprintf( '<!-- wp:image {"id":40,"width":300,"height":200,"sizeSlug":"responsive-content-image"} -->
+<figure class="wp-block-image size-responsive-content-image is-resized"><img src="%1$s/dog-400x0-c-default.jpg" alt="" class="wp-image-%2$s" width="300" height="200"/><figcaption>Image with a caption and a break<br>at 100%</figcaption></figure>
+<!-- /wp:image -->',
+			$this->get_upload_url(),
+			$image->ID
+		);
+
+		$content = trim( do_blocks( $content ) );
+
+		$expected = sprintf(
+			'<figure class="wp-block-image size-responsive-content-image is-resized"><img width="300" height="200" srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" alt="" class="wp-image-%2$s"><figcaption>Image with a caption and a break<br>at 100/figcaption></figure>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+		$result = $rci->make_content_images_responsive( $content );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	function test_block_image_with_alt_text() {
+		$image = $this->create_image();
+		$rci   = new Responsive_Content_Images();
+
+		$content = sprintf( '<!-- wp:image {"id":40,"sizeSlug":"responsive-content-image"} -->
+<figure class="wp-block-image size-responsive-content-image"><img src="%1$s/dog-400x0-c-default.jpg" alt="A dog wrapped in a blanket" class="wp-image-%2$s"/></figure>
+<!-- /wp:image -->',
+			$this->get_upload_url(),
+			$image->ID
+		);
+
+		$content = trim( do_blocks( $content ) );
+
+		$expected = sprintf(
+			'<figure class="wp-block-image size-responsive-content-image"><img alt="A dog wrapped in a blanket" srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" class="wp-image-%2$s"></figure>',
+			$this->get_upload_url(),
+			$image->ID
+		);
+		$result = $rci->make_content_images_responsive( $content );
+
+		$this->assertEquals( $expected, $result );
+	}
 }

--- a/tests/timmy-sizes.php
+++ b/tests/timmy-sizes.php
@@ -14,27 +14,27 @@ add_image_size( 'large', 0, 0 );
  */
 add_filter( 'timmy/sizes', function( $sizes ) {
 	return array_merge( $sizes, [
-		'thumbnail'           => [
+		'thumbnail'                => [
 			'resize'     => [ 150, 150 ],
 			'name'       => 'Thumbnail',
 			'post_types' => [ 'all' ],
 			'sizes'      => '100vw',
 		],
-		'resize-only'         => [
+		'resize-only'              => [
 			'resize' => [ 500 ],
 		],
 		// For better compatibility with other plugins, define the 'large' image size.
-		'large'               => [
+		'large'                    => [
 			'resize' => [ 1400 ],
 			'srcset' => [ [ 560 ] ],
 			'sizes'  => '100vw',
 		],
-		'large-x-descriptors' => [
+		'large-x-descriptors'      => [
 			'resize' => [ 1400 ],
 			'srcset' => [ [ 560 ], '1x', '1.5x' ],
 			'sizes'  => '100vw',
 		],
-		'header-wide'         => [
+		'header-wide'              => [
 			'resize'                => [ 1400 ],
 			'srcset'                => [
 				[ 768, 329 ],
@@ -45,6 +45,11 @@ add_filter( 'timmy/sizes', function( $sizes ) {
 			'generate_srcset_sizes' => true,
 			'show_in_ui'            => false,
 			'post_types'            => [ 'page' ],
+		],
+		'responsive-content-image' => [
+			'resize' => [ 400 ],
+			'srcset' => [ [ 370 ], [ 768 ] ],
+			'sizes'  => '100vw',
 		],
 	] );
 } );


### PR DESCRIPTION
This pull request will add support for the [Responsive Content Images](https://github.com/mindkomm/timmy/blob/master/docs/responsive-content-images.md) feature as requested in #26.