### PR TITLE
make_content_images_responsive regex is too greedy

### DIFF
--- a/lib/Responsive_Content_Images.php
+++ b/lib/Responsive_Content_Images.php
@@ -86,7 +86,7 @@ class Responsive_Content_Images {
 		 * - The part after "size-" to catch the name of the image size that’s used.
 		 */
 		if ( preg_match_all(
-			'/<figure class="([^"]*wp-block-image size-([^\s]+)\s?[^"]*)"[^>]*><img [^>]+>.*<\/figure>/',
+			'/<figure class="([^"]*wp-block-image size-(\w+).*?)".*?><img [^>]+>.*<\/figure>/',
 			$content,
 			$block_images
 		) ) {


### PR DESCRIPTION
It would include trailing `"><..."` after the class name.

Example string and resulting `$block_images` variable:
`$str = '\n<figure class="wp-block-image size-large"><a href="https://foo"><img src="/uploads/2020/02/hello-1024x0-c-default.jpg" alt="" class="wp-image-22361"/></a></figure>\n';`

Before, notice the `large"><a`
```
array(3) {
  [0] =>
  array(1) {
    [0] =>
    string(163) "<figure class="wp-block-image size-large"><a href="https://foo"><img src="/uploads/2020/02/hello-1024x0-c-default.jpg" alt="" class="wp-image-22361"/></a></figure>"
  }
  [1] =>
  array(1) {
    [0] =>
    string(35) "wp-block-image size-large"><a href="
  }
  [2] =>
  array(1) {
    [0] =>
    string(9) "large"><a"
  }
}
```

After
```
array(3) {
  [0] =>
  array(1) {
    [0] =>
    string(163) "<figure class="wp-block-image size-large"><a href="https://foo"><img src="/uploads/2020/02/hello-1024x0-c-default.jpg" alt="" class="wp-image-22361"/></a></figure>"
  }
  [1] =>
  array(1) {
    [0] =>
    string(25) "wp-block-image size-large"
  }
  [2] =>
  array(1) {
    [0] =>
    string(5) "large"
  }
}
```


This warning:
`PHP Warning:  array_merge(): Expected parameter 1 to be an array, bool given in /vendor/mindkomm/timmy/functions-images.php on line 244` was seen during Gutenberg editing and due to the call to
`get_timber_image_attributes_responsive($timber_image = 22361, $size = 'large"><a', $args = *uninitialized*) at `/vendor/mindkomm/timmy/lib/Responsive_Content_Images.php:271`


Note: I didn't heavily tested the regexp so you'll probably want to add a couple of testcases before before merging ;)