### PR TITLE
1.x Improve handling of full size images

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -127,7 +127,7 @@ class Image {
 				$this->full_src,
 				$this->max_width,
 				$this->max_height
-				) = wp_get_attachment_image_src( $this->id, 'full' );
+			) = wp_get_attachment_image_src( $this->id, 'full' );
 		}
 	}
 
@@ -292,10 +292,10 @@ class Image {
 		}
 
 		if ( ! $this->is_full_size() ) {
-		$source_attributes = Helper::responsive_source_attributes( $this, $args, $mime_type );
-		$source_attributes = array_merge( $source_attributes, $light_attributes );
+			$source_attributes = Helper::responsive_source_attributes( $this, $args, $mime_type );
+			$source_attributes = array_merge( $source_attributes, $light_attributes );
 
-		$html .= '<source' . Helper::get_attribute_html( $source_attributes ) . '>' . PHP_EOL;
+			$html .= '<source' . Helper::get_attribute_html( $source_attributes ) . '>' . PHP_EOL;
 		}
 
 		// Add fallback.
@@ -576,7 +576,7 @@ class Image {
 			$width  = $this->max_width();
 			$height = $this->max_height();
 		} else {
-		list( $width, $height ) = Helper::get_dimensions_for_size( $this->size );
+			list( $width, $height ) = Helper::get_dimensions_for_size( $this->size );
 		}
 
 		if ( $this->is_svg() ) {
@@ -606,7 +606,7 @@ class Image {
 			$width  = $this->max_width();
 			$height = $this->max_height();
 		} else {
-		list( $width, $height ) = Helper::get_dimensions_for_size( $this->size );
+			list( $width, $height ) = Helper::get_dimensions_for_size( $this->size );
 		}
 
 		if ( $this->is_svg() ) {
@@ -995,6 +995,17 @@ class Image {
 			&& $this->size['webp']
 			&& ! $this->is_svg()
 			&& ! $this->is_pdf();
+	}
+
+	/**
+	 * Sets whether an image will be converted to WebP.
+	 *
+	 * @param bool $webp Whether to convert the image to WebP.
+	 *
+	 * @return void
+	 */
+	public function set_webp( bool $webp ) {
+		$this->size['webp'] = $webp;
 	}
 
 	/**

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -198,7 +198,7 @@ class Image {
 	 */
 	public function src( $args = [] ) {
 		// @todo Test with false image or wrong image size key.
-		if ( $this->is_full_size() ) {
+		if ( $this->is_full_size() || $this->is_svg() ) {
 			return $this->auto_full_src();
 		}
 
@@ -291,7 +291,7 @@ class Image {
 			$html .= '<source' . Helper::get_attribute_html( $source_attributes ) . '>' . PHP_EOL;
 		}
 
-		if ( ! $this->is_full_size() ) {
+		if ( ! $this->is_full_size() && ! $this->is_svg() ) {
 			$source_attributes = Helper::responsive_source_attributes( $this, $args, $mime_type );
 			$source_attributes = array_merge( $source_attributes, $light_attributes );
 
@@ -787,7 +787,7 @@ class Image {
 		 * The full size may be a scaled version of the image. To always request the original
 		 * version, 'original' has to be used as the size.
 		 */
-		if ( $this->is_full_size() ) {
+		if ( $this->is_full_size() || $this->is_svg() ) {
 			$attributes['src'] = $this->auto_full_src();
 		} else {
 			$srcset = $this->srcset( [ 'webp' => $args['webp'] ] );
@@ -982,7 +982,7 @@ class Image {
 	 * @return bool
 	 */
 	public function is_full_size() {
-		return in_array( $this->size_key, [ 'full', 'original' ], true ) || $this->is_svg();
+		return in_array( $this->size_key, [ 'full', 'original' ], true );
 	}
 
 	/**

--- a/tests/test-color-scheme-dark.php
+++ b/tests/test-color-scheme-dark.php
@@ -27,6 +27,26 @@ class TestColorSchemeDark extends TimmyUnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
+	public function test_picture_full() {
+		$attachment = $this->create_image();
+		$attachment_dark = $this->create_image( [
+			'file' => 'test-color-scheme-dark.jpg',
+		] );
+
+		$image = Timmy::get_image( $attachment->ID, 'full' );
+		$image->set_color_scheme_dark_image( $attachment_dark->ID );
+
+		$result = $image->picture_responsive();
+
+		$expected = sprintf(
+			'<source srcset="%1$s/test-color-scheme-dark.jpg" media="(prefers-color-scheme: dark)">%2$s<img src="%1$s/test.jpg" width="2400" height="1600" alt="" loading="lazy">',
+			$this->get_upload_url(),
+			PHP_EOL
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
 	public function test_picture_loading_false() {
 		$attachment      = $this->create_image();
 		$attachment_dark = $this->create_image( [ 'file' => 'test-color-scheme-dark.jpg' ] );

--- a/tests/test-picture.php
+++ b/tests/test-picture.php
@@ -20,6 +20,22 @@ class TestPicture extends TimmyUnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
+	public function test_picture_with_full_src() {
+		$attachment = $this->create_image( [
+			'alt' => 'Burrito Wrap',
+		] );
+
+		$image  = Timmy::get_image( $attachment, 'full' );
+		$result = $image->picture_responsive();
+
+		$expected = sprintf(
+			'<img src="%1$s/test.jpg" width="2400" height="1600" alt="Burrito Wrap" loading="lazy">',
+			$this->get_upload_url(),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
 	public function test_picture_loading_false() {
 		$attachment = $this->create_image();
 		$result     = get_timber_picture_responsive( $attachment, 'picture', [ 'loading' => false ] );

--- a/tests/test-svg.php
+++ b/tests/test-svg.php
@@ -33,7 +33,7 @@ class TestSvg extends TimmyUnitTestCase {
 		$attachment = $this->create_image( [ 'file' => 'sveegee.svg' ] );
 		$result     = get_timber_image_responsive( $attachment, 'large' );
 
-		$image = ' src="' . $this->get_upload_url() . '/sveegee.svg" width="1400" height="1400" loading="lazy" alt=""';
+		$image = ' src="' . $this->get_upload_url() . '/sveegee.svg" width="400" height="400" loading="lazy" alt=""';
 
 		$this->assertEquals( $image, $result );
 	}

--- a/tests/test-svg.php
+++ b/tests/test-svg.php
@@ -33,7 +33,7 @@ class TestSvg extends TimmyUnitTestCase {
 		$attachment = $this->create_image( [ 'file' => 'sveegee.svg' ] );
 		$result     = get_timber_image_responsive( $attachment, 'large' );
 
-		$image = ' src="' . $this->get_upload_url() . '/sveegee.svg" width="400" height="400" loading="lazy" alt=""';
+		$image = ' src="' . $this->get_upload_url() . '/sveegee.svg" width="1400" height="1400" loading="lazy" alt=""';
 
 		$this->assertEquals( $image, $result );
 	}

--- a/tests/test-timmy.php
+++ b/tests/test-timmy.php
@@ -107,7 +107,7 @@ class TestTimmy extends TimmyUnitTestCase {
 		$this->assertEquals( $image, $result );
 	}
 
-	public function test_timmy_ignores_sgv() {
+	public function test_timmy_ignores_svg() {
 		$filter = function( $ignore) {
 			$this->assertEquals( true, $ignore );
 

--- a/tests/test-webp.php
+++ b/tests/test-webp.php
@@ -91,6 +91,23 @@ class TestWebP extends TimmyUnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
+	public function test_picture_with_full_src_webp() {
+		$attachment = $this->create_image();
+
+		$image = Timmy::get_image( $attachment, 'full' );
+		$image->set_webp( true );
+
+		$result = $image->picture_responsive();
+
+		$expected = sprintf(
+			'<source type="image/webp" srcset="%1$s/test.jpg">%2$s<img src="%1$s/test.jpg" width="2400" height="1600" alt="" loading="lazy">',
+			$this->get_upload_url(),
+			PHP_EOL
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
 	public function test_picture_webp_args_array_with_srcset_descriptors() {
 		$attachment = $this->create_image();
 		$result     = get_timber_picture_responsive( $attachment, [


### PR DESCRIPTION
Fixes some bugs when working with the `full` image size.

- Fixes a bug when the `full` size was used with `Image::picture_responsive()`.
- Introduces `Image::is_full_size()` to check whether a full size should be returned.
- Introduces `Image::auto_full_src()` to automatically return the correct URL for a full size based on the size key.
- Introduces a new `set_webp()` method to enabled/disable WebP for an image with `full` size key.