### PR TITLE
1.x Fix a bug when Gif images were converted to WebP images

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -250,7 +250,7 @@ class Image {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$to_webp   = ! empty( $this->size['webp'] );
+		$to_webp   = $this->is_webp();
 		$mime_type = false;
 		$html      = '';
 
@@ -994,6 +994,7 @@ class Image {
 		return isset( $this->size['webp'] )
 			&& $this->size['webp']
 			&& ! $this->is_svg()
+			&& ! $this->is_gif()
 			&& ! $this->is_pdf();
 	}
 

--- a/tests/test-webp.php
+++ b/tests/test-webp.php
@@ -163,4 +163,33 @@ class TestWebP extends TimmyUnitTestCase {
 
 		$this->assertEquals( 'image/jpeg', $metadata['sizes']['large']['mime-type'] );
 	}
+
+	public function test_timmy_ignores_gif_when_using_webp() {
+		$attachment = $this->create_image( [ 'file' => 'logo-small.gif' ] );
+
+		$image = Timmy::get_image( $attachment, 'webp' );
+
+		$result   = $image->picture_responsive();
+		$expected = sprintf(
+			'<source srcset="%1$s/logo-small-100x0-c-default.gif">
+<img src="http://example.org/wp-content/uploads/2023/04/logo-small-100x0-c-default.gif" width="100" height="50" alt="" loading="lazy">',
+			$this->get_upload_url()
+		);
+
+		$this->assertSame( $expected, $result );
+	}
+
+	public function test_timmy_ignores_svg_when_using_webp() {
+		$attachment = $this->create_image( [ 'file' => 'sveegee.svg' ] );
+
+		$image = Timmy::get_image( $attachment, 'webp' );
+
+		$result   = $image->picture_responsive();
+		$expected = sprintf(
+			'<img src="%1$s/sveegee.svg" width="400" height="400" alt="" loading="lazy">',
+			$this->get_upload_url()
+		);
+
+		$this->assertSame( $expected, $result );
+	}
 }

--- a/tests/test-webp.php
+++ b/tests/test-webp.php
@@ -186,7 +186,7 @@ class TestWebP extends TimmyUnitTestCase {
 
 		$result   = $image->picture_responsive();
 		$expected = sprintf(
-			'<img src="%1$s/sveegee.svg" width="400" height="400" alt="" loading="lazy">',
+			'<img src="%1$s/sveegee.svg" width="1400" height="1400" alt="" loading="lazy">',
 			$this->get_upload_url()
 		);
 


### PR DESCRIPTION
This pull request fixes a bug when Gif images were converted to WebP images.

In theory, animated Gif images can be converted to WebP images. But PHP’s `imagewebp()` uses the GD (Graphics Draw) library, which only works with single-frame images and does not support the conversion of animated GIFs to WebP.