### PR TITLE
1.x Fix some bugs where Timmy resized images unnecessarily

### DIFF
--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -1,5 +1,7 @@
 <?php
 
+use Timmy\Timmy;
+
 class TestFunctions extends TimmyUnitTestCase {
 	public function test_get_timber_image_src() {
 		$attachment = $this->create_image();
@@ -10,17 +12,27 @@ class TestFunctions extends TimmyUnitTestCase {
 		$this->assertEquals( $image, $result );
 	}
 
+	public function test_get_timber_image_src_small_image() {
+		$attachment = $this->create_image( [ 'file' => 'test-200px.jpg' ] );
+
+		$image  = Timmy::get_image( $attachment, 'large' );
+		$result = $image->src();
+
+		$image = $this->get_upload_url() . '/test-200px.jpg';
+
+		$this->assertEquals( $image, $result );
+	}
+
 	public function test_get_timber_image_src_without_metadata() {
 		$attachment = $this->create_image();
 
 		// Remove attachment metadata.
 		wp_update_attachment_metadata( $attachment->ID, [] );
 
-		$result = get_timber_image_src( $attachment, 'large' );
+		$result   = get_timber_image_src( $attachment, 'large' );
+		$expected = $this->get_upload_url() . '/test-1400x0-c-default.jpg';
 
-		$image = $this->get_upload_url() . '/test-1400x0-c-default.jpg';
-
-		$this->assertEquals( $image, $result );
+		$this->assertEquals( $expected, $result );
 	}
 
 	public function test_get_timber_image_src_non_image() {
@@ -276,6 +288,28 @@ class TestFunctions extends TimmyUnitTestCase {
 		$this->assertEquals( $image, $result );
 	}
 
+	public function test_get_timber_image_full_with_gif_apiv1() {
+		$attachment = $this->create_image( [ 'file' => 'logo-small.gif' ] );
+
+		$image  = Timmy::get_image( $attachment, 'full' );
+		$result = $image->src();
+
+		$expected = $this->get_upload_url() . '/logo-small.gif';
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	public function test_get_timber_image_large_with_gif() {
+		$attachment = $this->create_image( [ 'file' => 'logo-small.gif' ] );
+
+		$image  = Timmy::get_image( $attachment, 'large' );
+		$result = $image->src();
+
+		$expected = $this->get_upload_url() . '/logo-small.gif';
+
+		$this->assertEquals( $expected, $result );
+	}
+
 	public function test_get_timber_image_full_with_gif_without_metadata() {
 		$attachment = $this->create_image( [ 'file' => 'logo-small.gif' ] );
 
@@ -332,7 +366,7 @@ class TestFunctions extends TimmyUnitTestCase {
 	public function test_get_timber_image_width() {
 		$attachment = $this->create_image();
 
-		$image  = Timmy\Timmy::get_image( $attachment, 'large' );
+		$image  = Timmy::get_image( $attachment, 'large' );
 		$result = $image->width();
 
 		$this->assertEquals( 1400, $result );
@@ -344,7 +378,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		// Remove attachment metadata.
 		wp_update_attachment_metadata( $attachment->ID, [] );
 
-		$image  = Timmy\Timmy::get_image( $attachment, 'large' );
+		$image  = Timmy::get_image( $attachment, 'large' );
 		$result = $image->width();
 
 		$this->assertEquals( 1400, $result );
@@ -353,7 +387,7 @@ class TestFunctions extends TimmyUnitTestCase {
 	public function test_get_timber_image_height() {
 		$attachment = $this->create_image();
 
-		$image  = Timmy\Timmy::get_image( $attachment, 'large' );
+		$image  = Timmy::get_image( $attachment, 'large' );
 		$result = $image->height();
 
 		$this->assertEquals( 933, $result );
@@ -365,7 +399,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		// Remove attachment metadata.
 		wp_update_attachment_metadata( $attachment->ID, [] );
 
-		$image  = Timmy\Timmy::get_image( $attachment, 'large' );
+		$image  = Timmy::get_image( $attachment, 'large' );
 		$result = $image->height();
 
 		// Can’t calculate a height.

--- a/tests/test-webp.php
+++ b/tests/test-webp.php
@@ -68,7 +68,7 @@ class TestWebP extends TimmyUnitTestCase {
 		$result     = get_timber_picture_responsive( $attachment, 'picture-webp-with-small-image' );
 
 		$expected = sprintf(
-			'<source type="image/webp" srcset="%1$s/test-200px-200x0-c-default.webp">%2$s<source type="image/jpeg" srcset="%1$s/test-200px-200x0-c-default.jpg">%2$s<img src="%1$s/test-200px-200x0-c-default.jpg" width="200" height="133" alt="" loading="lazy">',
+			'<source type="image/webp" srcset="%1$s/test-200px.webp">%2$s<source type="image/jpeg" srcset="%1$s/test-200px.jpg">%2$s<img src="%1$s/test-200px.jpg" width="200" height="133" alt="" loading="lazy">',
 			$this->get_upload_url(),
 			PHP_EOL
 		);
@@ -171,9 +171,9 @@ class TestWebP extends TimmyUnitTestCase {
 
 		$result   = $image->picture_responsive();
 		$expected = sprintf(
-			'<source srcset="%1$s/logo-small-100x0-c-default.gif">
-<img src="http://example.org/wp-content/uploads/2023/04/logo-small-100x0-c-default.gif" width="100" height="50" alt="" loading="lazy">',
-			$this->get_upload_url()
+			'<source srcset="%1$s/logo-small.gif">%2$s<img src="http://example.org/wp-content/uploads/2023/04/logo-small.gif" width="100" height="50" alt="" loading="lazy">',
+			$this->get_upload_url(),
+			PHP_EOL
 		);
 
 		$this->assertSame( $expected, $result );


### PR DESCRIPTION
This pull request fixes some bugs when Timmy resized images to the same size as the original size. This happened for images that were smaller than the requested size for images where the `full` size was requested.