### PR TITLE
Preserve the class attribute on fallback IMG in PICTURE

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -348,6 +348,10 @@ class Image {
 			'loading' => $this->loading( $args['loading'] ),
 		];
 
+		if (!empty($args['class'])) {
+			$fallback_attributes['class'] = $args['class'];
+		}
+
 		$fallback_attributes = $this->add_data_attributes( $fallback_attributes, $args );
 
 		return '<img' . Helper::get_attribute_html( $fallback_attributes ) . '>';


### PR DESCRIPTION
When using `<picture>` some styles still need to be applied on the `<img>`. One example would be `object-fit`. So we need a way to provide a CSS class to the fallack `<img>` inside the picture to apply those styles to it.

This MR checks if a class attribute is available and if so, preserves it on the `<img>`.

Usage: `post.thumbnail|get_timber_picture_responsive($image_size, {class: 'theClass'})` which will set the class attribute of `<img>` to `theClass`