### PR TITLE
don't guard against non-"attachment" post-type

### DIFF
--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -136,10 +136,6 @@ class Timmy {
 			$attachment = (int) $attachment['ID'];
 		}
 
-		if ( 'attachment' !== get_post_type( $attachment ) ) {
-			return null;
-		}
-
 		$class      = apply_filters( 'timmy/image/class', Image::class );
 		$size_array = $size;
 


### PR DESCRIPTION
This code-path can't be override (contrary to checks done by the Timmy\Image constructor. Be it for usage with custom-post-type or subclassing attachment, or any other plugin edge-case, this check would be better left to a place it can be skipped/made optional.