### PR TITLE
feat: Remove check for attachment post type that can’t be overridden

### DIFF
--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -136,10 +136,6 @@ class Timmy {
 			$attachment = (int) $attachment['ID'];
 		}
 
-		if ( 'attachment' !== get_post_type( $attachment ) ) {
-			return null;
-		}
-
 		$class      = apply_filters( 'timmy/image/class', Image::class );
 		$size_array = $size;
 

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -136,6 +136,15 @@ class Timmy {
 			$attachment = (int) $attachment['ID'];
 		}
 
+		// Check if we work with a WordPress post. This doesn’t necessarily have
+		// to be an attachment, that’s why we don’t check for the 'attachment'
+		// post type.
+		$wp_post = \get_post( $attachment );
+
+		if ( ! $wp_post ) {
+			return null;
+		}
+
 		$class      = apply_filters( 'timmy/image/class', Image::class );
 		$size_array = $size;
 

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -36,7 +36,7 @@ class TestFunctions extends TimmyUnitTestCase {
 	}
 
 	public function test_get_timber_image_src_non_image() {
-		$result = get_timber_image_src( 'gaga', 'large' );
+		$result = get_timber_image_src( 0, 'large' );
 
 		$this->assertEquals( false, $result );
 	}
@@ -64,7 +64,7 @@ class TestFunctions extends TimmyUnitTestCase {
 	}
 
 	public function test_get_timber_image_non_image() {
-		$result = get_timber_image( 'gaga', 'large' );
+		$result = get_timber_image( 0, 'large' );
 
 		$this->assertEquals( false, $result );
 	}
@@ -373,7 +373,7 @@ class TestFunctions extends TimmyUnitTestCase {
 	}
 
 	public function test_get_timber_image_srcset_non_image() {
-		$result = get_timber_image_srcset( 'gaga', 'large' );
+		$result = get_timber_image_srcset( 0, 'large' );
 
 		$this->assertEquals( false, $result );
 	}


### PR DESCRIPTION
Ticket

- #82 

This pull request removes a check that requires that an ID passed to Timmy::get_image() has be a WordPress post with an `attachment` post type. Instead, it now only checks if it is a WordPress post.

This allows developers to work with post types that work the same as attachments, but don’t have `attachment` as post type.