### PR TITLE
Add filter hook for WebP image conversion

### DIFF
--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -631,7 +631,7 @@ class Timmy {
 
 		// Maybe convert to WebP.
 		if (
-			self::should_convert_to_webp( $file_src, $img_size )
+			self::should_convert_to_webp( $attachment_id, $file_src, $img_size )
 			/**
 			 * We don’t want to convert to WebP when the image size is saved in the metadata of an
 			 * image, which happens when generating a downsized version. Saving the image sizes in
@@ -871,23 +871,34 @@ class Timmy {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $file_src The src of the original image.
-	 * @param array  $img_size Configuration values for an image size.
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $file_src      The src of the original image.
+	 * @param array  $img_size      Configuration values for an image size.
 	 *
 	 * @return bool
 	 */
-	public static function should_convert_to_webp( $file_src, $img_size ) {
+	public static function should_convert_to_webp( $attachment_id, $file_src, $img_size ) {
+		$should_convert = false;
+		
 		if ( isset( $img_size['webp'] )
 			&& $img_size['webp']
 			&& 'application/pdf' !== wp_check_filetype(
 				$file_src,
 				Helper::get_mime_types()
-            )['type']
+			)['type']
 		) {
-			return true;
+			$should_convert = true;
 		}
-
-		return false;
+	
+		/**
+		 * Filter whether an image should be converted to WebP.
+		 *
+		 * @param bool   $should_convert Whether the image should be converted to WebP.
+		 * @param int    $attachment_id  Attachment ID.
+		 * @param string $file_src      The source path of the original image.
+		 * @param array  $img_size      Configuration values for the image size.
+		 */
+		return apply_filters( 'timmy/should_convert_to_webp', $should_convert, $attachment_id, $file_src, $img_size );
 	}
 
 	/**
@@ -1068,7 +1079,7 @@ class Timmy {
 			$src = self::resize( $img_size, $file_src, $width, $height, $crop, $force );
 
 			// Maybe convert to webp.
-			if ( self::should_convert_to_webp( $file_src, $img_size ) ) {
+			if ( self::should_convert_to_webp($attachment->ID, $file_src, $img_size ) ) {
 				self::to_webp( $src, $img_size );
 			}
 		}


### PR DESCRIPTION
**Description**
This PR adds a new filter hook `timmy/should_convert_to_webp` that gives developers finer-grained control over which images should be converted to WebP format.

**Changes**
1. Modified `should_convert_to_webp()` method to accept an $attachment_id parameter
2. Added a WordPress filter hook to allow per-image control of WebP conversion
3. Updated all method calls throughout the codebase to include the attachment ID parameter

**Usage Example**
```php
// Prevent WebP conversion for site icons
add_filter( 'timmy/should_convert_to_webp', function( $should_convert, $attachment_id, $file_src, $img_size ) {
    $site_icon_id = get_option('site_icon');
    
    if ($site_icon_id && $site_icon_id == $attachment_id) {
        return false;
    }
    
    return $should_convert;
}, 10, 4);
```

This PR implements the solution proposed in issue #89 