### PR TITLE
feat: Add `timmy/should_convert_to_webp` filter

### DIFF
--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -631,7 +631,7 @@ class Timmy {
 
 		// Maybe convert to WebP.
 		if (
-			self::should_convert_to_webp( $file_src, $img_size )
+			self::should_convert_to_webp( $attachment_id, $file_src, $img_size )
 			/**
 			 * We don’t want to convert to WebP when the image size is saved in the metadata of an
 			 * image, which happens when generating a downsized version. Saving the image sizes in
@@ -871,23 +871,34 @@ class Timmy {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $file_src The src of the original image.
-	 * @param array  $img_size Configuration values for an image size.
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $file_src      The src of the original image.
+	 * @param array  $img_size      Configuration values for an image size.
 	 *
 	 * @return bool
 	 */
-	public static function should_convert_to_webp( $file_src, $img_size ) {
+	public static function should_convert_to_webp( $attachment_id, $file_src, $img_size ) {
+		$should_convert = false;
+		
 		if ( isset( $img_size['webp'] )
 			&& $img_size['webp']
 			&& 'application/pdf' !== wp_check_filetype(
 				$file_src,
 				Helper::get_mime_types()
-            )['type']
+			)['type']
 		) {
-			return true;
+			$should_convert = true;
 		}
-
-		return false;
+	
+		/**
+		 * Filter whether an image should be converted to WebP.
+		 *
+		 * @param bool   $should_convert Whether the image should be converted to WebP.
+		 * @param int    $attachment_id  Attachment ID.
+		 * @param string $file_src      The source path of the original image.
+		 * @param array  $img_size      Configuration values for the image size.
+		 */
+		return apply_filters( 'timmy/should_convert_to_webp', $should_convert, $attachment_id, $file_src, $img_size );
 	}
 
 	/**
@@ -1068,7 +1079,7 @@ class Timmy {
 			$src = self::resize( $img_size, $file_src, $width, $height, $crop, $force );
 
 			// Maybe convert to webp.
-			if ( self::should_convert_to_webp( $file_src, $img_size ) ) {
+			if ( self::should_convert_to_webp($attachment->ID, $file_src, $img_size ) ) {
 				self::to_webp( $src, $img_size );
 			}
 		}

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -631,7 +631,7 @@ class Timmy {
 
 		// Maybe convert to WebP.
 		if (
-			self::should_convert_to_webp( $attachment_id, $file_src, $img_size )
+			self::should_convert_to_webp( $file_src, $img_size, $attachment_id )
 			/**
 			 * We don’t want to convert to WebP when the image size is saved in the metadata of an
 			 * image, which happens when generating a downsized version. Saving the image sizes in
@@ -871,15 +871,15 @@ class Timmy {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int    $attachment_id Attachment ID.
 	 * @param string $file_src      The src of the original image.
 	 * @param array  $img_size      Configuration values for an image size.
+	 * @param ?int   $attachment_id Attachment ID.
 	 *
 	 * @return bool
 	 */
-	public static function should_convert_to_webp( $attachment_id, $file_src, $img_size ) {
+	public static function should_convert_to_webp( $file_src, $img_size, ?int $attachment_id = null ) {
 		$should_convert = false;
-		
+
 		if ( isset( $img_size['webp'] )
 			&& $img_size['webp']
 			&& 'application/pdf' !== wp_check_filetype(
@@ -889,16 +889,18 @@ class Timmy {
 		) {
 			$should_convert = true;
 		}
-	
+
 		/**
-		 * Filter whether an image should be converted to WebP.
+		 * Filters whether an image should be converted to WebP.
 		 *
 		 * @param bool   $should_convert Whether the image should be converted to WebP.
-		 * @param int    $attachment_id  Attachment ID.
-		 * @param string $file_src      The source path of the original image.
-		 * @param array  $img_size      Configuration values for the image size.
+		 * @param ?int   $attachment_id  Attachment ID.
+		 * @param string $file_src       The source path of the original image.
+		 * @param array  $img_size       Configuration values for the image size.
 		 */
-		return apply_filters( 'timmy/should_convert_to_webp', $should_convert, $attachment_id, $file_src, $img_size );
+		$should_convert = apply_filters( 'timmy/should_convert_to_webp', $should_convert, $attachment_id, $file_src, $img_size );
+
+        return $should_convert;
 	}
 
 	/**
@@ -1079,7 +1081,7 @@ class Timmy {
 			$src = self::resize( $img_size, $file_src, $width, $height, $crop, $force );
 
 			// Maybe convert to webp.
-			if ( self::should_convert_to_webp($attachment->ID, $file_src, $img_size ) ) {
+			if ( self::should_convert_to_webp( $file_src, $img_size, $attachment->ID ) ) {
 				self::to_webp( $src, $img_size );
 			}
 		}

--- a/tests/test-webp.php
+++ b/tests/test-webp.php
@@ -192,4 +192,16 @@ class TestWebP extends TimmyUnitTestCase {
 
 		$this->assertSame( $expected, $result );
 	}
+
+    public function test_should_convert_to_webp_filter() {
+        $this->add_filter_temporarily( 'timmy/should_convert_to_webp', '__return_false' );
+
+		$attachment = $this->create_image();
+
+		$image     = wp_get_attachment_image_src( $attachment->ID, 'webp' );
+		$file_path = $this->get_upload_path() . '/test-1400x0-c-default.webp';
+
+		$this->assertEquals( $this->get_upload_url() . '/test-1400x0-c-default.jpg', $image[0] );
+		$this->assertFileDoesNotExist( $file_path );
+	}
 }


### PR DESCRIPTION
This PR builds on the work of https://github.com/mindkomm/timmy/pull/90 with the following changes:

- Moves the `$attachment_id` parameter to the end of the parameters list to avoid a breaking change.
- Makes the `$attachment_id` parameter optional.
- Adds a test.

Revolves #89.
Resolves #90.
