### PR TITLE
feat: Add `show_in_rest` config parameter and filter

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -3,6 +3,7 @@
 - [Filters](#filters)
 	- [timmy/sizes](#timmysizes)
 	- [timmy/resize/ignore](#timmyresizeignore)
+	- [timmy/show_in_rest](#timmyshow_in_rest)
 	- [timmy/generate_srcset_sizes](#timmygenerate_srcset_sizes)
 	- [timmy/upscale](#timmyupscale)
 	- [timmy/use_src_default](#timmyuse_src_default)
@@ -64,9 +65,9 @@ Filters whether an image should be shown in the REST API.
 - **$show_in_rest**  
 	*(bool)* Whether to show the image in the REST API. Default `true`.
 - **$attachment_id**  
-	*(string)* The attachment ID.
-- **$$img_size**  
-	*(string)* Configuration values for the image size.
+	*(int* The attachment ID.
+- **$img_size**  
+	*(array)* Configuration values for the image size.
 
 **Example 1**
 
@@ -84,13 +85,6 @@ add_filter('timmy/show_in_rest', static function($show_in_rest, $attachment_id, 
 
     return $show_in_rest;
 }, 10, 3);
-```
-
-**Example 3**
-
-```php
-// Only show an image size when accessing the media endpoint directly.
-
 ```
 
 ### timmy/generate_srcset_sizes

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -60,6 +60,8 @@ add_filter( 'timmy/resize/ignore', function( $return, $attachment ) {
 
 Filters whether an image should be shown in the REST API.
 
+This filter only runs then a REST request to an attachment is actually made, so any logic you apply here will only be applied for REST requests to `wp/v2/media` or endpoints that use [media embeds](https://developer.wordpress.org/rest-api/using-the-rest-api/linking-and-embedding/#embedding).
+
 **Parameters**
 
 - **$show_in_rest**  

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -55,6 +55,44 @@ add_filter( 'timmy/resize/ignore', function( $return, $attachment ) {
 
 ---
 
+### timmy/show_in_rest
+
+Filters whether an image should be shown in the REST API.
+
+**Parameters**
+
+- **$show_in_rest**  
+	*(bool)* Whether to show the image in the REST API. Default `true`.
+- **$attachment_id**  
+	*(string)* The attachment ID.
+- **$$img_size**  
+	*(string)* Configuration values for the image size.
+
+**Example 1**
+
+```php
+// Don’t show any image size in REST API calls.
+add_filter('timmy/show_in_rest', '__return_false');
+```
+
+**Example 2**
+
+```php
+// Set `show_in_rest` based on the value in `show_in_ui`.
+add_filter('timmy/show_in_rest', static function($show_in_rest, $attachment_id, $img_size) {
+    $show_in_rest = $img_size['show_in_ui'] ?? false;
+
+    return $show_in_rest;
+}, 10, 3);
+```
+
+**Example 3**
+
+```php
+// Only show an image size when accessing the media endpoint directly.
+
+```
+
 ### timmy/generate_srcset_sizes
 
 Filters whether srcset sizes should be generated when an image is uploaded.

--- a/docs/image-configuration.md
+++ b/docs/image-configuration.md
@@ -280,9 +280,19 @@ The name parameter is used in the backend. When `show_in_ui` is `true`, then thi
 
 (`bool`), optional, Default: `true`
 
-When you set this to false, the user will not be able to select that value in the backend, e.g. when she wants to insert a Media file directly into the WYSYWIG content.
+When you set this to `false`, the user will not be able to select that value in the backend, e.g. when they want to insert a Media file directly into the WYSYWIG content.
 
 If the post type a user is editing is not in the `post_types` array (and if `post_types` is not `all`, the size will not be shown to the user.
+
+---
+
+### show_in_rest
+
+(`bool`), optional, Default: `true`
+
+Defines whether the image size should be shown in the REST API.
+
+You can use the [`timmy/show_in_rest` filter](#timmy-show-in-rest) to control this behavior for individual images.
 
 ---
 

--- a/docs/image-configuration.md
+++ b/docs/image-configuration.md
@@ -292,7 +292,7 @@ If the post type a user is editing is not in the `post_types` array (and if `pos
 
 Defines whether the image size should be shown in the REST API.
 
-You can use the [`timmy/show_in_rest` filter](#timmy-show-in-rest) to control this behavior for individual images.
+You can use the [`timmy/show_in_rest` filter](./hooks.md#timmyshow_in_rest) to control this behavior for individual images.
 
 ---
 
@@ -302,7 +302,7 @@ You can use the [`timmy/show_in_rest` filter](#timmy-show-in-rest) to control th
 
 Per default, all the sizes defined under `srcset` will only be generated when the image is requested in the frontend. Only the size defined in `resize` will be generated. By setting this to true, srcset sizes will also be generated when an image is uploaded.
 
-You can use the [`timmy/generate_srcset_sizes` filter](#timmy-generate-srcset-sizes) to enable or disable this globally. Setting this option on an image size always takes precedence over the filter.
+You can use the [`timmy/generate_srcset_sizes` filter](./hooks.md#timmygenerate_srcset_sizes) to enable or disable this globally. Setting this option on an image size always takes precedence over the filter.
 
 ---
 

--- a/docs/image-configuration.md
+++ b/docs/image-configuration.md
@@ -91,6 +91,7 @@ You shouldn’t use `full` or `original` as keys in your configuration. If you d
 - [post_types](#post_types)
 - [name](#name)
 - [show_in_ui](#show_in_ui)
+- [show_in_rest](#show_in_rest)
 - [generate_srcset_sizes](#generate_srcset_sizes)
 - [upscale](#upscale) (formerly named `oversize`)
 - [webp](#webp)

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -718,9 +718,7 @@ class Timmy {
         // WP_REST_Posts_Controller::prepare_item_for_response() method, and then in the
         // WP_REST_Attachments_Controller::prepare_item_for_response() method. The first time, it
         // won’t have any media specific data. There’s where we hook in there.
-        if (empty($response->data['media_details'])) {
-            $this->is_serving_rest_attachment_request = true;
-        }
+        $this->is_serving_rest_attachment_request = empty($response->data['media_details']);
 
 		return $response;
 	}

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -4,6 +4,7 @@ namespace Timmy;
 
 use Timber;
 use WP_Post;
+use WP_REST_Response;
 
 /**
  * Class Timmy
@@ -22,6 +23,13 @@ class Timmy {
 	 * @var array
 	 */
 	public $image_sizes_for_ui = array();
+
+    /**
+     * Whether WordPress is serving a REST attachment request.
+     *
+     * @var bool
+     */
+    private bool $is_serving_rest_attachment_request = false;
 
 	/**
 	 * Timmy can’t be instantiated directly.
@@ -103,13 +111,15 @@ class Timmy {
 
 		// Filters the metadata for an image.
 		add_filter( 'wp_get_attachment_metadata', array( $this, 'filter_attachment_metadata' ), 10, 2 );
+		add_filter('rest_prepare_attachment', [$this, 'filter_rest_prepare_attachment']);
 
 		// Hook into generating attachment meta data filter.
 		add_filter( 'wp_generate_attachment_metadata', array( $this, 'delete_generated_image_sizes' ), 5, 2 );
 		add_filter( 'wp_generate_attachment_metadata', array( $this, 'filter_wp_generate_attachment_metadata' ), 30, 2 );
 
+
 		// Filters the attachment data prepared for JavaScript.
-		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'filter_wp_prepare_attachment_for_js' ), 10, 3 );
+		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'filter_wp_prepare_attachment_for_js' ) );
 
 		// Set global $_wp_additional_image_sizes.
 		$this->set_wp_additional_image_sizes();
@@ -309,9 +319,11 @@ class Timmy {
 		$configured_sizes = Helper::get_image_sizes();
 
         // Filter sizes for REST API requests.
-        $configured_sizes = array_filter($configured_sizes, function($img_size) use ($attachment_id) {
-           return $this->should_show_in_rest($img_size, $attachment_id);
-        });
+        if ($this->is_serving_rest_attachment_request) {
+            $configured_sizes = array_filter($configured_sizes, function($img_size) use ($attachment_id) {
+               return $this->should_show_in_rest($img_size, $attachment_id);
+            });
+        }
 
 		if ( ! isset( $meta_data['sizes'] ) && ! empty( $configured_sizes ) ) {
 			$meta_data['sizes'] = [];
@@ -668,11 +680,12 @@ class Timmy {
 			// Yoast SEO uses this for generating the OG image in the HTML head. But platforms like
 			// LinkedIn don’t support WebP images (yet). So we shouldn’t use it there.
 			! doing_filter( 'wp_generate_attachment_metadata' )
-            // We don’t want to convert to WebP when the image is served through the REST API.
-            // In \WP_REST_Attachments_Controller::prepare_item_for_response(), WordPress adds the
-            // mime type of the image to the response based on the attachment’s mime type. If we
-            // converted to WebP here, the mime type and the file ending wouldn’t be consistent.
-            && ! wp_is_serving_rest_request()
+            // We don’t want to convert to WebP when the image is served through the /wp/v2/media
+            // endpoint. In \WP_REST_Attachments_Controller::prepare_item_for_response(), WordPress
+            // adds the mime type of the image to the response based on the attachment’s mime type.
+            // If we converted to WebP here, the mime type and the file ending wouldn’t be
+            // consistent.
+            && ! $this->is_serving_rest_attachment_request
 			&& self::should_convert_to_webp( $file_src, $img_size, $attachment_id )
 		) {
 			$src = self::to_webp( $src, $img_size );
@@ -694,6 +707,28 @@ class Timmy {
 	}
 
 	/**
+	 * Prepares attachment for REST API.
+	 *
+	 * @param WP_REST_Response $response The response object.
+	 * @param WP_Post $post The original attachment post.
+	 * @param WP_REST_Request $request Request used to generate the response.
+	 */
+	public function filter_rest_prepare_attachment(WP_REST_Response $response): WP_REST_Response {
+        // If the media_details are not yet set, we can still hook into generating the data. By
+        // setting the $is_serving_rest_attachment_request flag, we can only target requests that
+        // are serving classic attachment requests.
+        // WordPress actually runs the `rest_prepare_attachment` hook twice. First in the
+        // WP_REST_Posts_Controller::prepare_item_for_response() method, and then in the
+        // WP_REST_Attachments_Controller::prepare_item_for_response() method. The first time, it
+        // won’t have any media specific data. There’s where we hook in there.
+        if (empty($response->data['media_details'])) {
+            $this->is_serving_rest_attachment_request = true;
+        }
+
+		return $response;
+	}
+
+	/**
 	 * Filters image data before it is returned to the Media view.
 	 *
 	 * When the details for an image are requested in the Media view, WordPress displays the large
@@ -710,7 +745,7 @@ class Timmy {
 	 *
 	 * @return array
 	 */
-	public function filter_wp_prepare_attachment_for_js( $response, $attachment, $meta ) {
+	public function filter_wp_prepare_attachment_for_js( array $response ) {
 		if ( isset( $response['sizes']['large'] ) ) {
 			$response['sizes']['large'] = $response['sizes']['full'];
 		}

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -232,8 +232,6 @@ class Timmy {
 		global $_wp_additional_image_sizes;
 
 		foreach ( Helper::get_image_sizes() as $key => $size ) {
-			$sizes[] = $key;
-
 			list( $width, $height ) = Helper::get_dimensions_for_size( $size );
 
 			$crop = isset( $size['resize'][1] ) ? true : false;
@@ -263,7 +261,6 @@ class Timmy {
 	 * We tell WordPress that we don’t have intermediate sizes, because we have our own image
 	 * thingy we want to work with.
 	 *
-	 *
 	 * @since 0.10.0
 	 * @see wp_generate_attachment_metadata()
 	 * @param array $sizes Image sizes.
@@ -276,9 +273,9 @@ class Timmy {
 	/**
 	 * Filters the attachment meta data.
 	 *
-	 * Adds missing image sizes to the sizes array dynamically. This is useful when image sizes are
-	 * requested in other places than your templates, e.g. through the media endpoint of REST API
-	 * in the Block Editor.
+	 * Adds missing image sizes to the sizes array dynamically. This is usefulwhen image sizes are
+	 * requested in other places than your templates, e.g. through the media
+     * endpoint of the REST API in the Block Editor.
 	 *
 	 * Image sizes can be missing when a new image size was added after an image was uploaded. This
 	 * can be circumvented when image meta data is regenerated, e.g. with Regenerate Thumbnails.
@@ -311,6 +308,11 @@ class Timmy {
 		$missing_sizes    = [];
 		$configured_sizes = Helper::get_image_sizes();
 
+        // Filter sizes for REST API requests.
+        $configured_sizes = array_filter($configured_sizes, function($img_size) use ($attachment_id) {
+           return $this->should_show_in_rest($img_size, $attachment_id);
+        });
+
 		if ( ! isset( $meta_data['sizes'] ) && ! empty( $configured_sizes ) ) {
 			$meta_data['sizes'] = [];
 		}
@@ -333,6 +335,15 @@ class Timmy {
 				);
 			}
 		}
+
+        // Make sure that the sizes array only contains the configured sizes.
+        // Any sizes that might be present in the meta data, but not in the
+        // configured sizes will be removed.
+        if (!empty($meta_data['sizes'])) {
+            $meta_data['sizes'] = array_filter($meta_data['sizes'], function($size_key) use ($configured_sizes) {
+                return in_array($size_key, array_keys($configured_sizes));
+            }, ARRAY_FILTER_USE_KEY);
+        }
 
 		return $meta_data;
 	}
@@ -614,6 +625,11 @@ class Timmy {
 			return $return;
 		}
 
+        // Filter size for REST API requests.
+        if (!$this->should_show_in_rest($img_size, $attachment_id)) {
+            return $return;
+        }
+
 		// Get meta data not filtered by Timmy.
 		$meta_data = wp_get_attachment_metadata( $attachment_id, true );
 
@@ -642,19 +658,22 @@ class Timmy {
 
 		// Maybe convert to WebP.
 		if (
-			self::should_convert_to_webp( $file_src, $img_size, $attachment_id )
-			/**
-			 * We don’t want to convert to WebP when the image size is saved in the metadata of an
-			 * image, which happens when generating a downsized version. Saving the image sizes in
-			 * the metadata happens inside the wp_generate_attachment_metadata filter, which we can
-			 * check for.
-			 *
-			 * If WebP images would be saved in the attachment metadata, WebP images would also be
-			 * used by other plugins, which can lead to unextected side effects. For example,
-			 * Yoast SEO uses this for generating the OG image in the HTML head. But platforms like
-			 * LinkedIn don’t support WebP images (yet). So we shouldn’t use it there.
-			 */
-			&& ! doing_filter( 'wp_generate_attachment_metadata' )
+			// We don’t want to convert to WebP when the image size is saved in the metadata of an
+			// image, which happens when generating a downsized version. Saving the image sizes in
+			// the metadata happens inside the wp_generate_attachment_metadata filter, which we can
+			// check for.
+            //
+			// If WebP images would be saved in the attachment metadata, WebP images would also be
+			// used by other plugins, which can lead to unexpected side effects. For example,
+			// Yoast SEO uses this for generating the OG image in the HTML head. But platforms like
+			// LinkedIn don’t support WebP images (yet). So we shouldn’t use it there.
+			! doing_filter( 'wp_generate_attachment_metadata' )
+            // We don’t want to convert to WebP when the image is served through the REST API.
+            // In \WP_REST_Attachments_Controller::prepare_item_for_response(), WordPress adds the
+            // mime type of the image to the response based on the attachment’s mime type. If we
+            // converted to WebP here, the mime type and the file ending wouldn’t be consistent.
+            && ! wp_is_serving_rest_request()
+			&& self::should_convert_to_webp( $file_src, $img_size, $attachment_id )
 		) {
 			$src = self::to_webp( $src, $img_size );
 		}
@@ -913,6 +932,42 @@ class Timmy {
 
         return $should_convert;
 	}
+
+    /**
+     * Checks whether an image should be shown in the REST API.
+     *
+     * @since 2.3.0
+     *
+     * @param array $img_size
+     * @param int $attachment_id
+     *
+     * @return bool
+     */
+    protected function should_show_in_rest(array $img_size, int $attachment_id): bool {
+        // Bail out if not a REST request.
+        if (!function_exists('wp_is_serving_rest_request') || !wp_is_serving_rest_request()) {
+            return true;
+        }
+
+        $show_in_rest = true;
+
+        if (isset($img_size['show_in_rest']) && $img_size['show_in_rest'] === false) {
+            $show_in_rest = false;
+        }
+
+        /**
+         * Filters whether an image should be shown in the REST API.
+         *
+         * @since 2.3.0
+         *
+         * @param bool  $show_in_rest Whether the image should be shown in the REST API.
+         * @param int   $attachment_id Attachment ID.
+         * @param array $img_size Configuration values for the image size.
+         */
+        $show_in_rest = apply_filters('timmy/show_in_rest', $show_in_rest, $attachment_id, $img_size);
+
+        return $show_in_rest;
+    }
 
 	/**
 	 * Get the actual width at which the image will be displayed.

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -318,11 +318,9 @@ class Timmy {
 		$configured_sizes = Helper::get_image_sizes();
 
         // Filter sizes for REST API requests.
-        if ($this->is_serving_rest_attachment_request) {
-            $configured_sizes = array_filter($configured_sizes, function($img_size) use ($attachment_id) {
-               return $this->should_show_in_rest($img_size, $attachment_id);
-            });
-        }
+        $configured_sizes = array_filter($configured_sizes, function($img_size) use ($attachment_id) {
+           return $this->should_show_in_rest($img_size, $attachment_id);
+        });
 
 		if ( ! isset( $meta_data['sizes'] ) && ! empty( $configured_sizes ) ) {
 			$meta_data['sizes'] = [];
@@ -979,7 +977,7 @@ class Timmy {
      */
     protected function should_show_in_rest(array $img_size, int $attachment_id): bool {
         // Bail out if not a REST request.
-        if (!$this->is_serving_rest_request()) {
+        if (!$this->is_serving_rest_request() || !$this->is_serving_rest_attachment_request) {
             return true;
         }
 

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -117,7 +117,6 @@ class Timmy {
 		add_filter( 'wp_generate_attachment_metadata', array( $this, 'delete_generated_image_sizes' ), 5, 2 );
 		add_filter( 'wp_generate_attachment_metadata', array( $this, 'filter_wp_generate_attachment_metadata' ), 30, 2 );
 
-
 		// Filters the attachment data prepared for JavaScript.
 		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'filter_wp_prepare_attachment_for_js' ) );
 

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -945,7 +945,7 @@ class Timmy {
      */
     protected function should_show_in_rest(array $img_size, int $attachment_id): bool {
         // Bail out if not a REST request.
-        if (!function_exists('wp_is_serving_rest_request') || !wp_is_serving_rest_request()) {
+        if (!$this->is_serving_rest_request()) {
             return true;
         }
 
@@ -968,6 +968,22 @@ class Timmy {
 
         return $show_in_rest;
     }
+
+    /**
+     * Checks whether an image should be shown in the REST API.
+     *
+     * @return bool
+     */
+	private function is_serving_rest_request(): bool {
+		if (!function_exists('wp_is_serving_rest_request')) {
+			return false;
+		}
+
+		// We need to use a custom filter timmy/is_serving_rest_request for testing purposes,
+		// because wp_is_serving_rest_request() is relying on the REST_REQUEST constanct, which
+		// we can’t enable or disable at will.
+		return wp_is_serving_rest_request() || apply_filters('timmy/is_serving_rest_request', false);
+	}
 
 	/**
 	 * Get the actual width at which the image will be displayed.

--- a/tests/TimmyUnitTestCase.php
+++ b/tests/TimmyUnitTestCase.php
@@ -118,6 +118,10 @@ abstract class TimmyUnitTestCase extends WP_UnitTestCase {
 		$attachment_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		$meta          = wp_generate_attachment_metadata( $attachment_id, $filename );
 
+		if ( 0 !== $post_id ) {
+			set_post_thumbnail( $post_id, $attachment_id );
+		}
+
 		wp_update_attachment_metadata( $attachment_id, $meta );
 
 		return $attachment_id;

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Timmy\Helper;
+
+class TestRest extends TimmyUnitTestCase {
+	function test_show_in_rest()
+    {
+		add_post_type_support( 'page', 'thumbnail' );
+
+        $post_id = self::factory()->post->create([
+			'post_type' => 'page',
+        ]);
+		$attachment_id = $this->create_image_attachment( $post_id );
+
+		// Simulate REST context
+	    if ( ! defined( 'REST_REQUEST' ) ) {
+	        define( 'REST_REQUEST', true );
+	    }
+
+		// Create REST request
+        $request = new WP_REST_Request( 'GET', rest_get_route_for_post_type_items('page') );
+		$request->set_param( '_embed', 'wp:featuredmedia' );
+		$request->set_param( 'per_page', 1 );
+		$response = rest_do_request( $request );
+		// Internal requests need to be handled differently.
+	    // @link https://developer.wordpress.org/rest-api/frequently-asked-questions/#how-do-i-use-the-_embed-parameter-on-internal-requests
+        $data = rest_get_server()->response_to_data( $response, true );
+
+	    $this->assertSame( 200, $response->get_status() );
+
+		$page = $data[0];
+		$sizes = $page['_embedded']['wp:featuredmedia'][0]['media_details']['sizes'];
+		$this->assertArrayNotHasKey('resize-only', $sizes);
+
+		$timmy_sizes = Helper::get_image_sizes();
+
+		// Same size because of the 'full' size that is present in generated sizes but no Timmy’s sizes.
+		$this->assertCount( count( $timmy_sizes ), $sizes );
+    }
+}

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -3,7 +3,7 @@
 use Timmy\Helper;
 
 class TestRest extends TimmyUnitTestCase {
-	function test_show_in_rest()
+	function test_show_in_rest_embedded()
     {
 		add_post_type_support( 'page', 'thumbnail' );
 
@@ -28,6 +28,30 @@ class TestRest extends TimmyUnitTestCase {
 	    $this->assertSame( 200, $response->get_status() );
 
 		$sizes = $data[0]['_embedded']['wp:featuredmedia'][0]['media_details']['sizes'];
+
+		$this->assertArrayNotHasKey('resize-only', $sizes);
+
+		// Same size because of the 'full' size that is present in generated sizes but no Timmy’s sizes.
+		$this->assertCount( count( Helper::get_image_sizes() ), $sizes );
+    }
+
+	function test_show_in_rest_attachment() {
+		$attachment_id = $this->create_image_attachment();
+
+		// Simulate REST context.
+	    // Can’t set REST_REQUEST constant here, because we can’t unset it again.
+	    $this->add_filter_temporarily('timmy/is_serving_rest_request', '__return_true');
+
+		// Create REST request
+        $request = new WP_REST_Request( 'GET', rest_get_route_for_post($attachment_id));
+		$response = rest_do_request( $request );
+		// Internal requests need to be handled differently.
+	    // @link https://developer.wordpress.org/rest-api/frequently-asked-questions/#how-do-i-use-the-_embed-parameter-on-internal-requests
+        $data = rest_get_server()->response_to_data( $response, true );
+
+	    $this->assertSame( 200, $response->get_status() );
+
+		$sizes = $data['media_details']['sizes'];
 
 		$this->assertArrayNotHasKey('resize-only', $sizes);
 

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -12,10 +12,9 @@ class TestRest extends TimmyUnitTestCase {
         ]);
 		$attachment_id = $this->create_image_attachment( $post_id );
 
-		// Simulate REST context
-	    if ( ! defined( 'REST_REQUEST' ) ) {
-	        define( 'REST_REQUEST', true );
-	    }
+		// Simulate REST context.
+	    // Can’t set REST_REQUEST constant here, because we can’t unset it again.
+	    $this->add_filter_temporarily('timmy/is_serving_rest_request', '__return_true');
 
 		// Create REST request
         $request = new WP_REST_Request( 'GET', rest_get_route_for_post_type_items('page') );
@@ -28,13 +27,11 @@ class TestRest extends TimmyUnitTestCase {
 
 	    $this->assertSame( 200, $response->get_status() );
 
-		$page = $data[0];
-		$sizes = $page['_embedded']['wp:featuredmedia'][0]['media_details']['sizes'];
+		$sizes = $data[0]['_embedded']['wp:featuredmedia'][0]['media_details']['sizes'];
+
 		$this->assertArrayNotHasKey('resize-only', $sizes);
 
-		$timmy_sizes = Helper::get_image_sizes();
-
 		// Same size because of the 'full' size that is present in generated sizes but no Timmy’s sizes.
-		$this->assertCount( count( $timmy_sizes ), $sizes );
+		$this->assertCount( count( Helper::get_image_sizes() ), $sizes );
     }
 }

--- a/tests/timmy-sizes.php
+++ b/tests/timmy-sizes.php
@@ -22,6 +22,7 @@ add_filter( 'timmy/sizes', function( $sizes ) {
 		],
 		'resize-only'                         => [
 			'resize' => [ 500 ],
+			'show_in_rest' => false,
 		],
 		'medium'                              => [
 			'resize' => [ 600 ],


### PR DESCRIPTION
Timmy had a problem where all image sizes would be generated when an **attachment would be accessed through the REST API endpoint `wp/v2/media` or if the embed parameters are used to embed image data in a post request**. This could lead to slow server response times and filling up the server with unused image sizes.

To fix this, I added a new `show_in_rest` parameter for the image configuration that you can set to `false`. I would advise that you go through your image configuration and set these parameters accordingly.

- Add a new `show_in_rest` parameter to the [image configuration](https://github.com/mindkomm/timmy/blob/2.x/docs/image-configuration.md).
- Add a new `timmy/show_in_rest` [filter hook](https://github.com/mindkomm/timmy/blob/2.x/docs/hooks.md) to filter whether an image should be included in REST API results for the attachment endpoint.
- Fix a bug where WebP image sources would be listed in a REST API request, even though the listed mime type of the image would be something else than WebP.