### PR TITLE
feat: Add timmy/resize/src_image_size filter

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -15,29 +15,52 @@ Consider the following image configuration:
 
 ```php
 add_filter( 'timmy/sizes', function( $sizes ) {
-    return array(
-        'thumbnail' => array(
-            'resize' => array( 150, 150 ),
-        ),
-        'small' => array(
-            'resize' => array( 370 ),
-            'srcset' => array( array( 570 ) ),
-        ),
-        'small-crop' => array(
-            'resize' => array( 370, 270 ),
-        ),
-        'large' => array(
-            'resize' => array( 1400 ),
-            'srcset' => array(
-                array( 370 ),
-                array( 570 ),
-            )
-        )
-    );
+    return [
+        'thumbnail' => [
+            'resize' => [ 150, 150 ],
+        ],
+        'small' => [
+            'resize' => [ 370 ],
+            'srcset' => [ [ 570 ] ],
+        ],
+        'small-crop' => [
+            'resize' => [ 370, 270 ],
+        ],
+        'large' => [
+            'resize' => [ 1400 ],
+            'srcset' => [
+                [ 370 ],
+                [ 570 ],
+            ]
+        ]
+    ];
 } );
 ```
 
 See how the image sizes use the same dimensions? By using a reduced set of dimensions throughout your configuration, you might get along with fewer image files.
+
+## Consider which images should be generated on upload and which on the fly
+
+Using the `post_types` option, you can define which image sizes should be generated on upload. All other image sizes will be generated on the fly. When you have a lot of image sizes that are generated on the fly, you might run into a maximum execution time error. But when you generate a lot of images on upload, you might generate too many image sizes that might not be used. So set your configuration carefully to find a good balance.
+
+## Scaled images
+
+Even though you use scaled images, Timmy will still generate the original image size. This is because Timmy tries to get the best quality of an image.
+
+To disable this behavior and make Timmy generate image sizes from a scaled image if scaled images are enabled, you can use the `timmy/resize/src_image_size` filter:
+
+```php
+// Don’t generate image sizes from full size images, but from scaled images.
+add_filter('timmy/resize/src_image_size', static function () {
+    return 'full';
+});
+```
+
+## Images requested through the REST API
+
+When you request an image through the REST API throught the `wp/v2/media` endpoint or through endpoints that use [media embeds](https://developer.wordpress.org/rest-api/using-the-rest-api/linking-and-embedding/#embedding), Timmy will generate missing image sizes on the fly. This is because WordPress will list all the image sizes that are available for a given image in the REST API response.
+
+You can disable single image size from showing up in the REST API response by using the [`show_in_rest` parameter](https://github.com/mindkomm/timmy/blob/2.x/docs/image-configuration.md#show_in_rest).
 
 ## Run Regenerate Thumbnails when you made changes to the image configuration
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -148,3 +148,14 @@ If you want to disable scaled images, you’ll have to use the [`big_image_size_
 ```php
 add_filter( 'big_image_size_threshold', '__return_false' );
 ```
+
+To not use any quality, Timmy will also **generate images from the original size**. This can a big performance hit. You might even run into memory issues if the site uses big high-res images that are a couple of MBs in file size.
+
+But you can tell Timmy to use the scaled images when generating image sizes using the `timmy/resize/src_image_size` filter:
+
+```php
+// Don’t generate image sizes from full size images, but from scaled images.
+add_filter('timmy/resize/src_image_size', static function () {
+    return 'full';
+});
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -56,6 +56,28 @@ add_filter( 'timmy/resize/ignore', function( $return, $attachment ) {
 
 ---
 
+### timmy/resize/src_image_size
+
+Filters the image size that is used to generate image sizes.
+
+**Parameters**
+
+- **$size**  
+	*(string)* Image size to use for resizing. Can be `full` or `original`. In case of `full`, a scaled image size will be used if scaled images are active. Default `original`.
+- **$attachment_id**  
+	*(int)* The attachment ID.
+
+**Example**
+
+```php
+// Don’t generate image sizes from full size images, but from scaled images.
+add_filter('timmy/resize/src_image_size', function () {
+    return 'full';
+});
+```
+
+---
+
 ### timmy/show_in_rest
 
 Filters whether an image should be shown in the REST API.

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -1217,7 +1217,7 @@ class Timmy {
      */
     private function get_image_src_for_resize(int $attachment_id): ?string {
         /**
-         * Filters the image size that is used to generate the srcset.
+         * Filters the image size that is used to generate image sizes.
          *
          * @param string $size Image size to use for resizing. Can be 'full' or 'original. In case
          *                     of 'full', a scaled image size will be used if scaled images are

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -379,10 +379,15 @@ class Timmy {
 			return $meta_data;
 		}
 
-		// Timber needs the file src as a URL.
-		$file_src = Helper::get_original_attachment_url( $attachment_id );
+		// Delete image sizes both for scaled and original images.
+		$original_src = Helper::get_original_attachment_url( $attachment_id );
+        $scaled_src = wp_get_attachment_url($attachment_id);
 
-		Timber\ImageHelper::delete_generated_files( $file_src );
+		Timber\ImageHelper::delete_generated_files( $original_src );
+
+        if ($original_src !== $scaled_src) {
+            Timber\ImageHelper::delete_generated_files( $scaled_src );
+        }
 
 		return $meta_data;
 	}
@@ -494,8 +499,7 @@ class Timmy {
 	 *                    the image is an intermediate size. False on failure.
 	 */
 	public function filter_image_downsize( $return, $attachment_id, $size ) {
-		// Timber needs the file src as a URL. Also checks if ID belongs to an attachment.
-		$file_src = Helper::get_original_attachment_url( $attachment_id );
+        $file_src = $this->get_image_src_for_resize($attachment_id);
 
 		if ( ! $file_src ) {
 			return false;
@@ -1148,21 +1152,21 @@ class Timmy {
 			: $generate_srcset_sizes;
 
 		// Bail out if srcset sizes shouldn’t be generated.
-		if ( false === $generate_srcset_sizes ) {
+		if ( false === $generate_srcset_sizes || ! isset( $img_size['srcset'] ) ) {
+			return;
+		}
+
+        // Timber needs the file src as an URL. Also checks if ID belongs to an
+        // attachment.
+		$file_src = $this->get_image_src_for_resize($attachment->ID);
+
+		if (! $file_src) {
 			return;
 		}
 
 		// Get values for the default image.
 		$crop  = Helper::get_crop_for_size( $img_size );
 		$force = Helper::get_force_for_size( $img_size );
-
-		// Timber needs the file src as an URL. Also checks if ID belongs to an attachment.
-		$file_src = Helper::get_original_attachment_url( $attachment->ID );
-
-		if ( ! isset( $img_size['srcset'] ) ) {
-			return;
-		}
-
 		$upscale = Helper::get_upscale_for_size( $img_size );
 
 		// Get meta data not filtered by Timmy.
@@ -1198,6 +1202,44 @@ class Timmy {
 			}
 		}
 	}
+
+    /**
+     * Gets the src for resizing.
+     *
+     * By default, the original image size is used, which ignores scaled image sizes for better
+     * quality. This is not always the best choice. For example, if you work with very large,
+     * high-resolution images, you might want to use the scaled image size to generated smaller
+     * image sizes.
+     *
+     * @param int $attachment_id
+     *
+     * @return string|null
+     */
+    private function get_image_src_for_resize(int $attachment_id): ?string {
+        /**
+         * Filters the image size that is used to generate the srcset.
+         *
+         * @param string $size Image size to use for resizing. Can be 'full' or 'original. In case
+         *                     of 'full', a scaled image size will be used if scaled images are
+         *                     active. Default 'original'.
+         * @param int $attachment_id Attachment ID.
+         */
+        $resize_src = apply_filters('timmy/resize/src_image_size', 'original', $attachment_id);
+
+		// Timber needs the file src as a URL. Also checks if ID belongs to an attachment.
+        switch ($resize_src) {
+            case 'full':
+            case 'scaled':
+                $file_src = wp_get_attachment_url( $attachment_id );
+                break;
+            case 'original':
+            default:
+		        $file_src = Helper::get_original_attachment_url( $attachment_id );
+                break;
+        }
+
+        return $file_src ?: null;
+    }
 
 	/**
 	 * Creates an image definition array that will be used for attachment metadata.


### PR DESCRIPTION
This PR adds a new `timmy/resize/src_image_size` filter.

Even though you might use scaled images, Timmy will still generate the original image size. This is because Timmy tries to get the best quality of an image. The downside of this is that it is a bigger impact on performance.

To disable this behavior and make Timmy generate image sizes from a scaled image if scaled images are enabled, you can use the `timmy/resize/src_image_size` filter:

```php
// Don’t generate image sizes from full size images, but from scaled images.
add_filter('timmy/resize/src_image_size', static function () {
    return 'full';
});
```