### PR TITLE
feat: Add `timmy/allowed_file_extensions` filter

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -199,3 +199,24 @@ add_filter( 'timmy/src_default', function( $src_default, $image ) {
     return $attributes['default_src'];
 }, 10, 2 );
 ```
+
+### timmy/allowed_file_extensions
+
+Filters the allowed file extensions to be processed with Timmy.
+ 
+**Parameters**
+
+- **$allowed_file_extensions**  
+    *(array)* Allowed file extensions. Default `[ 'jpg', 'jpeg', 'jpe', 'png' ]`.
+
+**Example**
+
+```php
+// Add support for AVIF and WebP files.
+add_filter( 'timmy/allowed_file_extensions', function( $allowed_file_extensions ) {
+    $allowed_file_extensions[] = 'avif';
+    $allowed_file_extensions[] = 'webp';
+    
+    return $allowed_file_extensions;
+} );
+```

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -1411,11 +1411,20 @@ class Timmy {
 			return true;
 		}
 
-		$allowed_ext = [ 'jpg', 'jpeg', 'jpe', 'png' ];
-		$file_ext    = wp_check_filetype( $file, Helper::get_mime_types() )['ext'];
+		$file_ext = wp_check_filetype( $file, Helper::get_mime_types() )['ext'];
+
+		$allowed_extensions = [ 'jpg', 'jpeg', 'jpe', 'png' ];
+
+		/**
+		 * Filters the allowed file extensions to be processed with Timmy.
+		 *
+		 * @since 2.5.0
+		 * @param array $allowed_extensions Array of allowed file extensions. Default ['jpg', 'jpeg', 'jpe', 'png'].
+		 */
+		$allowed_extensions = apply_filters( 'timmy/allowed_file_extensions', $allowed_extensions );
 
 		// We can’t use wp_attachment_is() for the check, because that will also allow GIF images.
-		if ( ! $file_ext || ! in_array( $file_ext, $allowed_ext, true ) ) {
+		if ( ! $file_ext || ! in_array( $file_ext, $allowed_extensions, true ) ) {
 			// Ignore.
 			return true;
 		}


### PR DESCRIPTION
- Adds a `timmy/allowed_file_extensions` filter
- Can be used to allow .avif and .webp images.

**Example**

```php
// Add support for AVIF and WebP files.
add_filter( 'timmy/allowed_file_extensions', function( $allowed_file_extensions ) {
    $allowed_file_extensions[] = 'avif';
    $allowed_file_extensions[] = 'webp';
    
    return $allowed_file_extensions;
} );
```