### PR TITLE
fix: Fix a type bug with parameter in `timmy/resize/ignore` filter

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,7 +35,7 @@ When true is returned in this filter, the function will bailout early and the im
 - **$attachment**  
 	*(string)* The attachment post.
 - **$size**  
-	*(string)* The requested image size.
+	*(string|array)* The requested image size as a string or array.
 - **$file_src**  
 	*(string)* The file src URL.
 

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -1091,6 +1091,6 @@ class Image {
     {
         return $this->is_svg()
                || $this->is_gif()
-               || Timmy::apply_ignore_filter($this->id, $this->size_key ?? '', $this->auto_full_src());
+               || Timmy::apply_ignore_filter($this->id, $this->size_key, $this->auto_full_src());
     }
 }

--- a/lib/Timmy.php
+++ b/lib/Timmy.php
@@ -1357,12 +1357,12 @@ class Timmy {
      * Applies the timmy/resize/ignore filter.
      *
      * @param int $attachment_id The attachment ID.
-     * @param string $size The requested image size.
+     * @param string|array $size The requested image size.
      * @param string $file_src The file src URL.
      *
      * @return bool
      */
-    public static function apply_ignore_filter(int $attachment_id, string $size, string $file_src) : bool
+    public static function apply_ignore_filter(int $attachment_id, $size, string $file_src) : bool
     {
         $attachment = get_post( $attachment_id );
 
@@ -1376,8 +1376,7 @@ class Timmy {
 		 *
 		 * @param bool   $ignore     Whether to ignore an image size. Default false.
 		 * @param int    $attachment The attachment post.
-		 * @param string $size       The requested image size. Empty string if the image size is
-		 *                           passed as an array directly.
+		 * @param string|array $size The requested image size as a string or array.
 		 * @param string $file_src   The file src URL.
 		 */
 		$ignore = apply_filters( 'timmy/resize/ignore',


### PR DESCRIPTION
In this PR, we remove the parameter type from `$size` in the `timmy/resize/ignore` filter to allow for the various cases of how an image size can be defined.

The `$size` parameter might be an array or a string, depending on where it is applied. If applied in the `image_downsize` filter, the `$size` parameter might also be an array with a width and height.