### PR TITLE
feat: Introduce new Image::set_attribute()

### DIFF
--- a/lib/AttributeSet.php
+++ b/lib/AttributeSet.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Timmy;
+
+/**
+ * Class AttributeSet
+ *
+ * Manages a set of HTML attributes.
+ */
+class AttributeSet {
+    protected array $html_attributes = [];
+
+	/**
+     * Sets an HTML attribute on the image
+     *
+     * @param string $attribute
+     * @param string $value
+     *
+     * @return void
+     */
+    public function set( string $attribute, string $value ) {
+        $this->html_attributes[$attribute] = $value;
+    }
+
+    /**
+     * Gets an attribute.
+     *
+     * @param string $attribute
+     *
+     * @return mixed|null
+     */
+    public function get( string $attribute ) {
+        return $this->html_attributes[$attribute] ?? null;
+    }
+
+    /**
+     * Gets all attributes, excluding empty ones.
+     *
+     * The alt attribute is always preserved.
+     */
+    public function get_all() {
+        return array_filter($this->html_attributes, static function($value, $key) {
+			// Always preserve alt attribute.
+			if ($key === 'alt') {
+				return true;
+			}
+
+            return !empty($value);
+        }, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Removes an attribute.
+     *
+     * @param string $attribute
+     *
+     * @return void
+     */
+    public function remove( string $attribute ) {
+        unset($this->html_attributes[$attribute]);
+    }
+
+    /**
+     * Renames an attribute.
+     *
+     * @param string $old_attribute
+     * @param string $new_attribute
+     *
+     * @return void
+     */
+    public function rename( string $old_attribute, string $new_attribute ) {
+        if (isset($this->html_attributes[$old_attribute])) {
+            $this->html_attributes[$new_attribute] = $this->html_attributes[$old_attribute];
+            unset($this->html_attributes[$old_attribute]);
+        }
+    }
+}

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -50,6 +50,8 @@ class Image {
 
 	protected $upscale;
 
+    protected AttributeSet $html_attributes;
+
 	/**
 	 * Image ID for dark mode / dark color scheme.
 	 *
@@ -99,6 +101,8 @@ class Image {
 		$image->resize_force = Helper::get_force_for_size( $image->size );
 		$image->upscale      = Helper::get_upscale_for_size( $image->size );
 
+        $image->html_attributes = new AttributeSet();
+
 		return $image;
 	}
 
@@ -120,6 +124,18 @@ class Image {
 	public function set_color_scheme_dark_image( int $image_id ) {
 		$this->color_scheme_dark_image = $image_id;
 	}
+
+    /**
+     * Sets an HTML attribute on the image
+     *
+     * @param string $attribute
+     * @param string $value
+     *
+     * @return void
+     */
+    public function set_attribute( string $attribute, string $value ) {
+        $this->html_attributes->set($attribute, $value);
+    }
 
 	protected function load_attachment_image_src() {
 		if ( empty( $this->full_src ) ) {
@@ -238,7 +254,7 @@ class Image {
 	/**
 	 * Get srcset and size for the image.
 	 *
-	 * @return string Image srcset, sizes, width, height alt attributes.
+	 * @return string Image srcset, sizes, width, height attributes.
 	 */
 	public function responsive_src( array $args = [] ) : string {
 		return Helper::get_attribute_html( $this->responsive_attributes( $args ) );
@@ -247,7 +263,7 @@ class Image {
 	/**
 	 * Get the responsive markup for the image.
 	 *
-	 * @return string Image srcset, sizes, width, height alt attributes.
+	 * @return string Image srcset, sizes, width, height, alt attributes.
 	 */
 	public function responsive( array $args = [] ) : string {
 		return Helper::get_attribute_html( array_merge( $this->responsive_attributes( $args ), [
@@ -341,21 +357,24 @@ class Image {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$fallback_attributes = [
-			'src'     => $this->src( [ 'webp' => false ] ),
-			'width'   => $this->width(),
-			'height'  => $this->height(),
-			'alt'     => $this->alt(),
-			'loading' => $this->loading( $args['loading'] ),
-		];
+        $attributes = new AttributeSet();
+
+        $attributes->set('src', $this->src([ 'webp' => false ]));
+        $attributes->set('width', $this->width());
+        $attributes->set('height', $this->height());
+        $attributes->set('alt', $this->alt());
+        $attributes->set('loading', $this->loading($args['loading']));
 
 		if (!empty($args['img_class'])) {
-			$fallback_attributes['class'] = $args['img_class'];
+            $attributes->set('class', $args['img_class']);
 		}
 
-		$fallback_attributes = $this->add_data_attributes( $fallback_attributes, $args );
+		$attributes = $this->add_data_attributes($attributes, $args);
 
-		return '<img' . Helper::get_attribute_html( $fallback_attributes ) . '>';
+		return '<img' . Helper::get_attribute_html( array_merge(
+            $attributes->get_all(),
+            $this->html_attributes->get_all()
+        ) ) . '>';
 	}
 
 	/**
@@ -823,7 +842,7 @@ class Image {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$attributes = [];
+		$attributes = new AttributeSet();
 
 		/**
 		 * Directly return full source when full source or an unsupported image for resize is
@@ -833,84 +852,76 @@ class Image {
 		 * version, 'original' has to be used as the size.
 		 */
 		if ( $this->is_full_size() || $this->is_ignored_for_resize() ) {
-			$attributes['src'] = $this->auto_full_src();
+            $attributes->set('src', $this->auto_full_src());
 		} else {
 			$srcset = $this->srcset( [ 'webp' => $args['webp'] ] );
 
 			if ( $srcset ) {
-				$attributes['srcset'] = $srcset;
+                $attributes->set('srcset', $srcset);
+                $attributes->set('sizes', $this->sizes());
 
 				if ( $args['src_default'] ) {
-					$attributes['src'] = $this->src_default();
+                    $attributes->set('src', $this->src_default());
 				}
-
-				$attributes['sizes'] = $this->sizes();
 			} else {
-				$attributes['src'] = $this->src( [ 'webp' => $args['webp'] ] );
+                $attributes->set('src', $this->src( [ 'webp' => $args['webp'] ] ));
 			}
 
-			$attributes['style'] = $this->style();
+            $attributes->set('style', $this->style());
 		}
 
 		if ( $args['attr_width'] ) {
-			$attributes['width'] = $this->width();
-			$attributes['style'] = false;
+            $attributes->set('width', $this->width());
+            $attributes->remove('style');
 		}
 
 		if ( $args['attr_height'] ) {
-			$attributes['height'] = $this->height();
-			$attributes['style']  = false;
+            $attributes->set('height', $this->height());
+            $attributes->remove('style');
 		}
 
 		// Lazy-loading.
-		$attributes['loading'] = $this->loading( $args['loading'] );
+        $attributes->set('loading', $this->loading( $args['loading'] ));
 
 		// Maybe update attributes with "data-" prefixes.
-		$attributes = $this->add_data_attributes( $attributes, $args );
+		$attributes = $this->add_data_attributes($attributes, $args);
 
 		// Maybe rename src attribute to srcset
-		if ( $args['is_source'] && ! empty( $attributes['src'] ) ) {
-			$attributes['srcset'] = $attributes['src'];
-			unset( $attributes['src'] );
+		if ( $args['is_source'] && ! empty( $attributes->get('src') ) ) {
+            $attributes->rename('src', 'srcset');
 		}
 
-		// Remove any falsy attributes.
-		$attributes = array_filter( $attributes );
-
-		return $attributes;
+		return $attributes->get_all();
 	}
 
 	/**
 	 * Adds "data-" attributes for usage with JavaScript lazy loading libraries.
 	 *
-	 * @param array $args       Args.
-	 * @param array $attributes Updated attributes.
+	 * @param AttributeSet $attributes
+	 * @param array $args
 	 *
 	 * @return mixed
 	 */
-	protected function add_data_attributes( array $attributes, array $args ) {
+	protected function add_data_attributes(AttributeSet $attributes, array $args) : AttributeSet {
 		$args = wp_parse_args( $args, [
 			'lazy_srcset' => false,
 			'lazy_src'    => false,
 			'lazy_sizes'  => false,
 		] );
 
-		if ( $args['lazy_srcset'] && ! empty( $attributes['srcset'] ) ) {
-			$attributes['data-srcset'] = $attributes['srcset'];
-			unset( $attributes['srcset'] );
+		if ( $args['lazy_srcset'] ) {
+            $attributes->rename('srcset', 'data-srcset');
 		}
 
-		if ( $args['lazy_src'] && ! empty( $attributes['src'] ) ) {
-			$attributes['data-src'] = $attributes['src'];
-			unset( $attributes['src'] );
+		if ( $args['lazy_src'] ) {
+            $attributes->rename('src', 'data-src');
 		}
 
-		if ( $args['lazy_sizes'] && ! empty( $attributes['sizes'] ) ) {
-			$attributes['data-sizes'] = $attributes['sizes'];
-			unset( $attributes['sizes'] );
+		if ( $args['lazy_sizes'] ) {
+            $attributes->rename('sizes', 'data-sizes');
 		}
 
-		return $attributes;
+        return $attributes;
 	}
 
 	public function resize_crop() {

--- a/tests/test-filters.php
+++ b/tests/test-filters.php
@@ -26,7 +26,7 @@ class TestFilters extends TimmyUnitTestCase {
 		$result     = get_timber_image_responsive( $attachment, 'large' );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="alternative_src_default" sizes="100vw" width="1400" height="933" loading="lazy" alt=""',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="alternative_src_default" width="1400" height="933" loading="lazy" alt=""',
 			$this->get_upload_url()
 		);
 

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -154,7 +154,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		$result     = get_timber_image_responsive( $attachment, 'large' );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt="Burrito Wrap"', $this->get_upload_url()
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt="Burrito Wrap"', $this->get_upload_url()
 		);
 
 		$this->assertEquals( $expected, $result );
@@ -171,7 +171,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		$result = $image->responsive();
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt="Burrito Wrap"', $this->get_upload_url()
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt="Burrito Wrap"', $this->get_upload_url()
 		);
 
 		$this->assertEquals( $expected, $result );
@@ -190,7 +190,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		$result = get_timber_image_responsive( $attachment, 'large' );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" loading="lazy" alt="Burrito Wrap"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" loading="lazy" alt="Burrito Wrap"',
 			$this->get_upload_url()
 		);
 
@@ -202,7 +202,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		$result     = get_timber_image_responsive_src( $attachment, 'large' );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy"',
 			$this->get_upload_url()
 		);
 
@@ -217,7 +217,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		wp_update_attachment_metadata( $attachment->ID, [] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy"',
 			$this->get_upload_url()
 		);
 
@@ -247,7 +247,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" height="933" loading="lazy"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" height="933" loading="lazy"',
 			$this->get_upload_url()
 		);
 
@@ -261,7 +261,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" loading="lazy"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" loading="lazy"',
 			$this->get_upload_url()
 		);
 
@@ -275,7 +275,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="eager"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="eager"',
 			$this->get_upload_url()
 		);
 
@@ -289,7 +289,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933"',
 			$this->get_upload_url()
 		);
 
@@ -306,7 +306,7 @@ class TestFunctions extends TimmyUnitTestCase {
 		] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933"',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933"',
 			$this->get_upload_url()
 		);
 

--- a/tests/test-responsive-content-images.php
+++ b/tests/test-responsive-content-images.php
@@ -14,7 +14,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		);
 
 		$expected = sprintf(
-			'<p><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="400" height="267" loading="lazy" alt="" class="alignnone size-responsive-content-image wp-image-%2$s"></p>',
+			'<p><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="400" height="267" loading="lazy" alt="" class="alignnone size-responsive-content-image wp-image-%2$s"></p>',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -35,7 +35,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		) ) );
 
 		$expected = sprintf(
-			'<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="400" height="267" loading="lazy" alt="" class="wp-image-%2$s"></figure>',
+			'<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="400" height="267" loading="lazy" alt="" class="wp-image-%2$s"></figure>',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -61,10 +61,10 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		$content = trim( do_blocks( $content ) );
 
 		$expected = sprintf(
-			'<p><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="400" height="267" loading="lazy" alt="" class="alignnone size-responsive-content-image wp-image-%2$s"></p>
+			'<p><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="400" height="267" loading="lazy" alt="" class="alignnone size-responsive-content-image wp-image-%2$s"></p>
 
 
-<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="400" height="267" loading="lazy" alt="" class="wp-image-%2$s"></figure>',
+<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="400" height="267" loading="lazy" alt="" class="wp-image-%2$s"></figure>',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -87,7 +87,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		$content = trim( do_blocks( $content ) );
 
 		$expected = sprintf(
-			'<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="400" height="267" loading="lazy" alt="" class="wp-image-%2$s"><figcaption>Image with a caption and a break<br>at 100 percent</figcaption></figure>',
+			'<figure class="wp-block-image size-responsive-content-image"><img srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="400" height="267" loading="lazy" alt="" class="wp-image-%2$s"><figcaption>Image with a caption and a break<br>at 100 percent</figcaption></figure>',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -110,7 +110,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		$content = trim( do_blocks( $content ) );
 
 		$expected = sprintf(
-			'<figure class="wp-block-image size-responsive-content-image is-resized"><img width="300" height="200" srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" loading="lazy" alt="" class="wp-image-%2$s"><figcaption>Image with a caption and a break<br>at 100 percent</figcaption></figure>',
+			'<figure class="wp-block-image size-responsive-content-image is-resized"><img width="300" height="200" srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" loading="lazy" alt="" class="wp-image-%2$s"><figcaption>Image with a caption and a break<br>at 100 percent</figcaption></figure>',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -133,7 +133,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		$content = trim( do_blocks( $content ) );
 
 		$expected = sprintf(
-			'<figure class="wp-block-image size-responsive-content-image"><img alt="A dog wrapped in a blanket" srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="400" height="267" loading="lazy" class="wp-image-%2$s"></figure>',
+			'<figure class="wp-block-image size-responsive-content-image"><img alt="A dog wrapped in a blanket" srcset="%1$s/test-370x0-c-default.jpg 370w, %1$s/test-400x0-c-default.jpg 400w, %1$s/test-768x0-c-default.jpg 768w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="400" height="267" loading="lazy" class="wp-image-%2$s"></figure>',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -156,7 +156,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		);
 
 		$expected = sprintf(
-			'\n<figure class="wp-block-image size-large"><a href="https://foo"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
+			'\n<figure class="wp-block-image size-large"><a href="https://foo"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -180,7 +180,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		);
 
 		$expected = sprintf(
-			'\n<figure class="wp-block-image alignfull size-large"><a href="https://example.org"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
+			'\n<figure class="wp-block-image alignfull size-large"><a href="https://example.org"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -204,7 +204,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		);
 
 		$expected = sprintf(
-			'\n<figure class="wp-block-image alignfull is-style-special size-large and-another"><a href="https://example.org"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
+			'\n<figure class="wp-block-image alignfull is-style-special size-large and-another"><a href="https://example.org"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
 			$this->get_upload_url(),
 			$image->ID
 		);
@@ -240,7 +240,7 @@ class TestResponsiveContentImages extends TimmyUnitTestCase {
 		);
 
 		$expected = sprintf(
-			'\n<figure class="wp-block-image alignfull size-gallery/full_screen.and-other"><a href="https://example.org"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
+			'\n<figure class="wp-block-image alignfull size-gallery/full_screen.and-other"><a href="https://example.org"><img srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt="" class="wp-image-%2$s"></a></figure>\n',
 			$this->get_upload_url(),
 			$image->ID
 		);

--- a/tests/test-timmy.php
+++ b/tests/test-timmy.php
@@ -29,7 +29,7 @@ class TestTimmy extends TimmyUnitTestCase {
 			$context
 		);
 		$expected = sprintf(
-			' data-srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt=""',
+			' data-srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt=""',
 			$this->get_upload_url()
 		);
 
@@ -41,7 +41,7 @@ class TestTimmy extends TimmyUnitTestCase {
 			$context
 		);
 		$expected = sprintf(
-			' data-srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" data-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt=""',
+			' data-srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" data-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt=""',
 			$this->get_upload_url()
 		);
 
@@ -53,7 +53,7 @@ class TestTimmy extends TimmyUnitTestCase {
 			$context
 		);
 		$expected = sprintf(
-			' data-srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" data-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-sizes="100vw" width="1400" height="933" loading="lazy" alt=""',
+			' data-srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" data-sizes="100vw" data-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt=""',
 			$this->get_upload_url()
 		);
 
@@ -90,7 +90,7 @@ class TestTimmy extends TimmyUnitTestCase {
 		] );
 
 		$expected = sprintf(
-			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" sizes="100vw" width="1400" height="933" loading="lazy" alt=""',
+			' srcset="%1$s/test-560x0-c-default.jpg 560w, %1$s/test-1400x0-c-default.jpg 1400w" sizes="100vw" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" width="1400" height="933" loading="lazy" alt=""',
 			$this->get_upload_url()
 		);
 

--- a/tests/timmy-sizes.php
+++ b/tests/timmy-sizes.php
@@ -109,19 +109,19 @@ add_filter( 'timmy/sizes', function( $sizes ) {
 				'allow' => true,
 			],
 		],
-		'deprecated-oversize'                 => [
-			'resize'   => [ 1404 ],
-			'srcset'   => [ [ 150 ] ],
-			'oversize' => [
-				'allow' => true,
-			],
-		],
 		'upscale-allow-true-style-attr-false' => [
 			'resize'  => [ 1405 ],
 			'srcset'  => [ [ 150 ] ],
 			'upscale' => [
 				'allow'      => true,
 				'style_attr' => false,
+			],
+		],
+		'deprecated-oversize'                 => [
+			'resize'   => [ 1404 ],
+			'srcset'   => [ [ 150 ] ],
+			'oversize' => [
+				'allow' => true,
 			],
 		],
 	] );


### PR DESCRIPTION
This PR introduces a new Image::set_attribute() function so that you can add other HTML attributes to your responsive image markup.

Here’s an example for setting a `style` attribute.

```php
$image->set_attribute('style', 'object-fit:cover;width:374px;height:150px');
```